### PR TITLE
test: refactor fixtures to load them automatically

### DIFF
--- a/backend/gn_module_monitoring/tests/conftest.py
+++ b/backend/gn_module_monitoring/tests/conftest.py
@@ -1,2 +1,8 @@
 from geonature.tests.fixtures import *
 from geonature.tests.fixtures import _session, app, users
+
+pytest_plugins = [
+    "gn_module_monitoring.tests.fixtures.module",
+    "gn_module_monitoring.tests.fixtures.site",
+    "gn_module_monitoring.tests.fixtures.sites_groups",
+]

--- a/backend/gn_module_monitoring/tests/test_monitoring/test_models/test_module.py
+++ b/backend/gn_module_monitoring/tests/test_monitoring/test_models/test_module.py
@@ -2,8 +2,6 @@ import pytest
 from geonature.utils.env import db
 
 from gn_module_monitoring.monitoring.models import TMonitoringModules
-from gn_module_monitoring.tests.fixtures.module import monitoring_module
-from gn_module_monitoring.tests.fixtures.site import categories, site_type
 
 
 @pytest.mark.usefixtures("temporary_transaction")

--- a/backend/gn_module_monitoring/tests/test_monitoring/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_monitoring/test_routes/test_site.py
@@ -1,8 +1,6 @@
 import pytest
 from flask import url_for
 
-from gn_module_monitoring.tests.fixtures.site import categories, site_type, sites
-
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestSite:

--- a/backend/gn_module_monitoring/tests/test_monitoring/test_routes/test_sites_groups.py
+++ b/backend/gn_module_monitoring/tests/test_monitoring/test_routes/test_sites_groups.py
@@ -1,8 +1,6 @@
 import pytest
 from flask import url_for
 
-from gn_module_monitoring.tests.fixtures.sites_groups import sites_groups
-
 
 @pytest.mark.usefixtures("client_class", "temporary_transaction")
 class TestSitesGroups:


### PR DESCRIPTION
Import fixtures from `conftest.py` via `pytest_plugins` as advised by the pytest documentation.
Need to launch tests from this repository directory and not from GeoNature repository directly. Otherwise, the following error can appear: 
```
Defining 'pytest_plugins' in a non-top-level conftest is no longer supported
```

In VsCode you can parametrize Python testing cwd parameter with : `${workspaceFolder}/backend/gn_module_monitoring/tests`. Here:
![image](https://user-images.githubusercontent.com/85738261/209231800-90eb0004-138f-4b10-b64a-12ca364a896a.png)

Careful, it could not work if you have specific pytest Args set in VsCode parameters