### PR TITLE
Feat/get all sites

### DIFF
--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -63,9 +63,17 @@ def get_sites():
 
 @blueprint.route("/sites/geometries", methods=["GET"])
 def get_all_site_geometries():
-    subquery = TMonitoringSites.query.with_entities(
-        TMonitoringSites.id_base_site, TMonitoringSites.base_site_name, TMonitoringSites.geom
-    ).subquery()
+    params = MultiDict(request.args)
+    subquery = (
+        TMonitoringSites.query.with_entities(
+            TMonitoringSites.id_base_site,
+            TMonitoringSites.base_site_name,
+            TMonitoringSites.geom,
+            TMonitoringSites.id_sites_group,
+        )
+        .filter_by_params(params)
+        .subquery()
+    )
 
     result = geojson_query(subquery)
 

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -4,14 +4,15 @@ from werkzeug.datastructures import MultiDict
 
 from gn_module_monitoring.blueprint import blueprint
 from gn_module_monitoring.monitoring.models import BibTypeSite, TMonitoringSites
+from gn_module_monitoring.monitoring.schemas import BibTypeSiteSchema, MonitoringSitesSchema
 from gn_module_monitoring.utils.routes import (
     filter_params,
+    geojson_query,
     get_limit_page,
     get_sort,
     paginate,
     sort,
 )
-from gn_module_monitoring.monitoring.schemas import MonitoringSitesSchema,BibTypeSiteSchema
 
 
 @blueprint.route("/sites/types", methods=["GET"])
@@ -58,6 +59,17 @@ def get_sites():
         limit=limit,
         page=page,
     )
+
+
+@blueprint.route("/sites/geometries", methods=["GET"])
+def get_all_site_geometries():
+    subquery = TMonitoringSites.query.with_entities(
+        TMonitoringSites.id_base_site, TMonitoringSites.base_site_name, TMonitoringSites.geom
+    ).subquery()
+
+    result = geojson_query(subquery)
+
+    return jsonify(result)
 
 
 @blueprint.route("/sites/module/<string:module_code>", methods=["GET"])

--- a/backend/gn_module_monitoring/tests/fixtures/site.py
+++ b/backend/gn_module_monitoring/tests/fixtures/site.py
@@ -7,7 +7,7 @@ from gn_module_monitoring.monitoring.models import TMonitoringSites
 
 
 @pytest.fixture()
-def sites(users, types_site, sites_groups):
+def sites(users, types_site, site_group_with_sites):
     user = users["user"]
     geom_4326 = from_shape(Point(43, 24), srid=4326)
     sites = {}
@@ -21,7 +21,7 @@ def sites(users, types_site, sites_groups):
             geom=geom_4326,
             id_nomenclature_type_site=types_site[key].id_nomenclature_type_site,
             types_site=[types_site[key]],
-            id_sites_group=sites_groups["Site_Groupe"].id_sites_group,
+            id_sites_group=site_group_with_sites.id_sites_group,
         )
     with db.session.begin_nested():
         db.session.add_all(sites.values())

--- a/backend/gn_module_monitoring/tests/fixtures/sites_groups.py
+++ b/backend/gn_module_monitoring/tests/fixtures/sites_groups.py
@@ -19,3 +19,8 @@ def sites_groups():
 @pytest.fixture
 def site_group_with_sites(sites_groups):
     return sites_groups["Site_Groupe"]
+
+
+@pytest.fixture
+def site_group_without_sites(sites_groups):
+    return sites_groups["Site_eolien"]

--- a/backend/gn_module_monitoring/tests/fixtures/sites_groups.py
+++ b/backend/gn_module_monitoring/tests/fixtures/sites_groups.py
@@ -14,3 +14,8 @@ def sites_groups():
         db.session.add_all(groups.values())
 
     return groups
+
+
+@pytest.fixture
+def site_group_with_sites(sites_groups):
+    return sites_groups["Site_Groupe"]

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -74,6 +74,17 @@ class TestSite:
             ][0]["id_base_site"]
             assert id_ == site.id_base_site
 
+    def test_get_all_site_geometries_filter_site_group(self, sites, site_group_without_sites):
+        r = self.client.get(
+            url_for(
+                "monitorings.get_all_site_geometries",
+                id_sites_group=site_group_without_sites.id_sites_group,
+            )
+        )
+        json_resp = r.json
+        features = json_resp.get("features")
+        assert features is None
+
     def test_get_module_sites(self):
         module_code = "TEST"
         r = self.client.get(url_for("monitorings.get_module_sites", module_code=module_code))

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -60,8 +60,19 @@ class TestSite:
     def test_get_all_site_geometries(self, sites):
         r = self.client.get(url_for("monitorings.get_all_site_geometries"))
 
-        assert r.content_type == "application/protobuf"
-        assert len(r.data) > 0
+        json_resp = r.json
+        features = json_resp.get("features")
+        sites_values = list(sites.values())
+        assert r.content_type == "application/json"
+        assert json_resp.get("type") == "FeatureCollection"
+        assert len(features) >= len(sites_values)
+        for site in sites_values:
+            id_ = [
+                obj["properties"]
+                for obj in features
+                if obj["properties"]["base_site_name"] == site.base_site_name
+            ][0]["id_base_site"]
+            assert id_ == site.id_base_site
 
     def test_get_module_sites(self):
         module_code = "TEST"

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -57,6 +57,12 @@ class TestSite:
         assert len(r.json["items"]) == 1
         assert r.json["items"][0]["id_base_site"] == id_base_site
 
+    def test_get_all_site_geometries(self, sites):
+        r = self.client.get(url_for("monitorings.get_all_site_geometries"))
+
+        assert r.content_type == "application/protobuf"
+        assert len(r.data) > 0
+
     def test_get_module_sites(self):
         module_code = "TEST"
         r = self.client.get(url_for("monitorings.get_module_sites", module_code=module_code))

--- a/backend/gn_module_monitoring/tests/test_routes/test_sites_groups.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_sites_groups.py
@@ -39,3 +39,18 @@ class TestSitesGroups:
         ).all()
         schema = MonitoringSitesGroupsSchema()
         assert [schema.dump(site) for site in groups]
+
+    def test_get_sites_groups_geometries(self, sites, site_group_with_sites):
+        r = self.client.get(url_for("monitorings.get_sites_group_geometries"))
+
+        json_resp = r.json
+        features = json_resp.get("features")
+        assert r.content_type == "application/json"
+        assert json_resp.get("type") == "FeatureCollection"
+        assert len(features) >= 1
+        id_ = [
+            obj["properties"]
+            for obj in features
+            if obj["properties"]["sites_group_name"] == site_group_with_sites.sites_group_name
+        ][0]["id_sites_group"]
+        assert id_ == site_group_with_sites.id_sites_group


### PR DESCRIPTION
Implementation of 2 routes (only the site one is functioning for now) to retrieve all the sites geometries and the sites groups.
Used the geobuf protocol : https://github.com/mapbox/geobuf since it is lighter than geojson. It has been used for more than 4000 wetlands (complex geometries) and it worked well

The sites_groups route is not fully implemented since the geom column must be defined and will be reworked in another PR
