### PR TITLE
fix(config): changed categories into items

### DIFF
--- a/backend/gn_module_monitoring/routes/data_utils.py
+++ b/backend/gn_module_monitoring/routes/data_utils.py
@@ -32,8 +32,7 @@ from geonature.utils.errors import GeoNatureError
 from ..blueprint import blueprint
 
 from ..config.repositories import get_config
-
-from ..monitoring.models import TMonitoringSitesGroups, TMonitoringSites
+from gn_module_monitoring.monitoring.models import TMonitoringSitesGroups, TMonitoringSites, BibCategorieSite
 
 model_dict = {
     "habitat": Habref,
@@ -41,6 +40,7 @@ model_dict = {
     "user": User,
     "taxonomy": Taxref,
     "dataset": TDatasets,
+    "categorie": BibCategorieSite,
     "observer_list": UserList,
     "taxonomy_list": BibListes,
     "sites_group": TMonitoringSitesGroups,

--- a/backend/gn_module_monitoring/routes/data_utils.py
+++ b/backend/gn_module_monitoring/routes/data_utils.py
@@ -32,7 +32,8 @@ from geonature.utils.errors import GeoNatureError
 from ..blueprint import blueprint
 
 from ..config.repositories import get_config
-from gn_module_monitoring.monitoring.models import TMonitoringSitesGroups, TMonitoringSites, BibCategorieSite
+
+from ..monitoring.models import TMonitoringSitesGroups, TMonitoringSites
 
 model_dict = {
     "habitat": Habref,
@@ -40,7 +41,6 @@ model_dict = {
     "user": User,
     "taxonomy": Taxref,
     "dataset": TDatasets,
-    "categorie": BibCategorieSite,
     "observer_list": UserList,
     "taxonomy_list": BibListes,
     "sites_group": TMonitoringSitesGroups,

--- a/config/monitoring/generic/module.json
+++ b/config/monitoring/generic/module.json
@@ -140,7 +140,7 @@
       "api" : "__MONITORINGS_PATH/sites/categories",
       "application": "GeoNature",
       "required": true,
-      "data_path": "categories",
+      "data_path": "items",
       "definition": "Permet de paramétrer la compatibilité de ce module avec les catégories de sites"
     },
     


### PR DESCRIPTION
Following the change with marshmallow schemas, the pagination schema returns the following data: 
```json
{
"count": int,
"limit": int,
"offset": int,
"items": list
}
```

Beforehand, `items` label changed depending on the object (site, category...). So need to update the config as well to follow theses changes