### PR TITLE
style: formatter json in flask admin

### DIFF
--- a/backend/gn_module_monitoring/monitoring/admin.py
+++ b/backend/gn_module_monitoring/monitoring/admin.py
@@ -1,11 +1,11 @@
 from flask_admin.contrib.sqla import ModelView
 from geonature.core.admin.admin import CruvedProtectedMixin
 from geonature.utils.env import DB
-from pypnnomenclature.models import TNomenclatures, BibNomenclaturesTypes
+from pypnnomenclature.models import BibNomenclaturesTypes, TNomenclatures
 from wtforms.validators import ValidationError
 
 from gn_module_monitoring.monitoring.models import BibTypeSite
-
+from gn_module_monitoring.monitoring.utils import json_formatter
 
 SITE_TYPE = "TYPE_SITE"
 
@@ -72,5 +72,5 @@ class BibTypeSiteView(CruvedProtectedMixin, ModelView):
     )
 
     column_list = ("nomenclature", "config")
-    column_formatters = dict(nomenclature=list_label_nomenclature_formatter)
+    column_formatters = dict(nomenclature=list_label_nomenclature_formatter, config=json_formatter)
     form_excluded_columns = "sites"

--- a/backend/gn_module_monitoring/monitoring/utils.py
+++ b/backend/gn_module_monitoring/monitoring/utils.py
@@ -1,0 +1,10 @@
+import json
+
+from jinja2.utils import markupsafe
+
+
+def json_formatter(view, context, model, name):
+    """Prettify JSON data in flask admin lists"""
+    value = getattr(model, name)
+    json_value = json.dumps(value, ensure_ascii=False, indent=2)
+    return markupsafe.Markup("<pre style='max-height: 500px;'>{}</pre>".format(json_value))


### PR DESCRIPTION
- Create jsonformatter inside utils.py
- Add formatter to column "config"

Reviewed-by: andriac
[Refs_ticket] : #59


Image coté front (column "config" formaté et scrollable si hauteur dépasse 500px) 
![image](https://user-images.githubusercontent.com/111564663/234517804-8e0dc874-8c30-4f5e-afdb-74e3ac84d14d.png)
