### PR TITLE
fix: prevent "Action" Clickable from datatable

### DIFF
--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.css
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.css
@@ -49,5 +49,9 @@
 /* Work around to make ng-content conditional 
 (not supported, maybe in Angular16) */
 .wrapper-button:not(:empty) + .default-button {
-    display: none;
+  display: none;
+}
+
+:host::ng-deep .datatable-header-cell[title=' Action'] * {
+  cursor: default !important;
 }

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -51,7 +51,7 @@
     (page)="setPage($event)"
     (sort)="onSortEvent($event)"
   >
-    <ngx-datatable-column [cellClass]="'cell-link'" prop="Action" class="object-link">
+    <ngx-datatable-column [cellClass]="'cell-link'" prop="Action" class="object-link" [sortable]="false">
       <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
         <!-- TODO Action Column : changer le (click)="navigateToDetail(row.id)-->
         <a

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -90,7 +90,7 @@ export class MonitoringDatatableGComponent implements OnInit {
   }
 
   onSortEvent($event) {
-    this.filters = {
+      this.filters = {
       ...this.filters,
       sort: $event.column.prop,
       sort_dir: $event.newValue,


### PR DESCRIPTION
- Change css to change cursor as default
- Detect if is Action prop on sortEvent to do nothing

Reviewed-by: andriac
[Refs_ticket]: #47

Closes #47 