### PR TITLE
Fix/delete site edit sitegroup

### DIFF
--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -157,9 +157,8 @@ def post_sites():
 def delete_site(_id):
     TMonitoringSites.query.filter_by(id_g=_id).delete()
     db.session.commit()
-    return {
-        "success": "Item is successfully deleted"
-    }, 200
+    return {"success": "Item is successfully deleted"}, 200
+
 
 @blueprint.route("/sites/<int:_id>", methods=["PATCH"])
 def patch_sites(_id):

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -155,11 +155,10 @@ def post_sites():
 
 @blueprint.route("/sites/<int:_id>", methods=["DELETE"])
 def delete_site(_id):
-    item = TMonitoringSites.find_by_id(_id)
-    db.session.delete(item)
+    TMonitoringSites.query.filter_by(id_g=_id).delete()
     db.session.commit()
     return {
-        "success": f"Item with {item.id_g} from table {item.__tablename__} is successfully deleted"
+        "success": "Item is successfully deleted"
     }, 200
 
 @blueprint.route("/sites/<int:_id>", methods=["PATCH"])

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -44,7 +44,7 @@ def get_sites_groups():
 @blueprint.route("/sites_groups/<int:id_sites_group>", methods=["GET"])
 def get_sites_group_by_id(id_sites_group: int):
     schema = MonitoringSitesGroupsSchema()
-    result = TMonitoringSitesGroups.find_by_id(id_sites_group)
+    result = TMonitoringSitesGroups.query.get_or_404(id_sites_group)
     return jsonify(schema.dump(result))
 
 


### PR DESCRIPTION
La suppression d'un site entrainait la suppression d'un groupe de site. Modification concernant la manière de supprimer le site coté backend . 
Modification de la méthode utilise pour vérifier qu'un groupe de site existe 