### PR TITLE
feat: use code list observers for observers site

### DIFF
--- a/backend/gn_module_monitoring/conf_schema_toml.py
+++ b/backend/gn_module_monitoring/conf_schema_toml.py
@@ -8,8 +8,9 @@ from marshmallow import Schema, fields
 
 
 class GnModuleSchemaConf(Schema):
-    DESCRIPTION_MODULE = fields.String(missing="Vous trouverez ici la liste des modules")
-    TITLE_MODULE = fields.String(missing="Module de suivi")
+    DESCRIPTION_MODULE = fields.String(default="Vous trouverez ici la liste des modules")
+    TITLE_MODULE = fields.String(default="Module de suivi")
+    CODE_OBSERVERS_LIST = fields.String(default="obsocctax")
 
 
 #     AREA_TYPE = fields.List(fields.String(), missing=["COM", "M1", "M5", "M10"])

--- a/frontend/app/services/config.service.ts
+++ b/frontend/app/services/config.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { ModuleService } from '@geonature/services/module.service';
-import { ModuleConfig } from '../module.config';
 import { of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { ConfigService as GnConfigService } from '@geonature/services/config.service';
@@ -67,10 +66,14 @@ export class ConfigService {
   }
 
   descriptionModule() {
-    return ModuleConfig.DESCRIPTION_MODULE;
+    return this.appConfig.MONITORINGS.DESCRIPTION_MODULE;
   }
   titleModule() {
-    return ModuleConfig.TITLE_MODULE;
+    return this.appConfig.MONITORINGS.TITLE_MODULE;
+  }
+
+  codeListObservers() {
+    return this.appConfig.MONITORINGS.CODE_OBSERVERS_LIST;
   }
   /** Frontend Module Monitoring Url */
   frontendModuleMonitoringUrl() {

--- a/frontend/app/services/monitoring-object.service.ts
+++ b/frontend/app/services/monitoring-object.service.ts
@@ -188,9 +188,10 @@ export class MonitoringObjectService {
         break;
       }
       case 'observers': {
+        const codeListObservers = this._configService.codeListObservers();
         x == null
           ? (x = [])
-          : (x = this._dataUtilsService.getUsersByCodeList(elem.code_list).pipe(
+          : (x = this._dataUtilsService.getUsersByCodeList(codeListObservers).pipe(
               mergeMap((users) => {
                 let currentUser;
                 if (Array.isArray(users)) {

--- a/monitorings_config.toml.example
+++ b/monitorings_config.toml.example
@@ -3,3 +3,6 @@
 #Possibilité de rajouter une description au module de suivi
 #DESCRIPTION_MODULE = "ceci est une description"
 #TITLE_MODULE = "Module de suivi"
+
+# code of the observator list -- utilisateurs.t_listes
+#CODE_OBSERVERS_LIST = "obsocctax"


### PR DESCRIPTION
Using config gn_config and add CODE_OBSERVERS_LIST to monitoring config to get list of observers (enter through site)

Reviewed-by: andriacap