### PR TITLE
feat: optional observers_txt field

### DIFF
--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -53,10 +53,11 @@
     },
     "id_inventor": {
       "type_widget": "observers",
-      "attribut_label": "Observateurs",
+      "attribut_label": "Observateur",
       "type_util": "user",
       "code_list":"CODE_OBSERVERS_LIST",
-      "required": true
+      "required": true,
+      "multi_select": false
     },
     "id_digitiser": {
       "type_widget": "text",

--- a/backend/gn_module_monitoring/config/generic/visit.json
+++ b/backend/gn_module_monitoring/config/generic/visit.json
@@ -51,7 +51,8 @@
       "keyLabel": "nom_complet",
       "type_util": "user",
       "multiple": true,
-      "required": true
+      "hidden": "({value}) => Object.keys(value).includes('observers_txt')",
+      "required": "({value}) => !Object.keys(value).includes('observers_txt')"
     },
 
     "id_digitiser": {


### PR DESCRIPTION
Add multiselect to false for field observers in site.json (only one id_inventor in DB)

Add conditional `required` and `hidden` to `observers` field for `visit.json`

PR linked: https://github.com/PnX-SI/GeoNature/pull/2692
Reviewed-by: andriacap