### PR TITLE
Feat/permission

### DIFF
--- a/backend/gn_module_monitoring/migrations/fc90d31c677f_declare_available_permissions.py
+++ b/backend/gn_module_monitoring/migrations/fc90d31c677f_declare_available_permissions.py
@@ -20,6 +20,17 @@ def upgrade():
     op.execute(
         """
         INSERT INTO
+            gn_permissions.t_objects(
+            code_object,
+            description_object
+            )
+        VALUES
+            ('TYPES_SITES','Types de sites à associer aux protocoles du module MONITORINGS')
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO
             gn_permissions.t_permissions_available (
                 id_module,
                 id_object,
@@ -37,9 +48,18 @@ def upgrade():
             (
                 VALUES
                     ('MONITORINGS', 'ALL', 'R', False, 'Accéder au module'),
-                    ('MONITORINGS', 'ALL', 'C', False, 'Creation de types de site'),
-                    ('MONITORINGS', 'ALL', 'U', False, 'Edition de types de site'),
-                    ('MONITORINGS', 'ALL', 'D', False, 'Suppression de types de site')
+                    ('MONITORINGS', 'TYPES_SITES', 'R', False, 'Accéder aux types de site'),
+                    ('MONITORINGS', 'TYPES_SITES', 'C', False, 'Créer des types de site'),
+                    ('MONITORINGS', 'TYPES_SITES', 'U', False, 'Modifier des types de site'),
+                    ('MONITORINGS', 'TYPES_SITES', 'D', False, 'Supprimer des types de site'),
+                    ('MONITORINGS', 'GNM_SITES', 'R', False, 'Accéder aux sites'),
+                    ('MONITORINGS', 'GNM_SITES', 'C', False, 'Créer des sites'),
+                    ('MONITORINGS', 'GNM_SITES', 'U', False, 'Modifier des sites'),
+                    ('MONITORINGS', 'GNM_SITES', 'D', False, 'Supprimer des sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'R', False, 'Accéder aux groupes de sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'C', False, 'Créer des groupes de sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'U', False, 'Modifier des groupes de sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'D', False, 'Supprimer des groupes de sites')
             ) AS v (module_code, object_code, action_code, scope_filter, label)
         JOIN
             gn_commons.t_modules m ON m.module_code = v.module_code

--- a/backend/gn_module_monitoring/migrations/fc90d31c677f_declare_available_permissions.py
+++ b/backend/gn_module_monitoring/migrations/fc90d31c677f_declare_available_permissions.py
@@ -52,14 +52,14 @@ def upgrade():
                     ('MONITORINGS', 'TYPES_SITES', 'C', False, 'Créer des types de site'),
                     ('MONITORINGS', 'TYPES_SITES', 'U', False, 'Modifier des types de site'),
                     ('MONITORINGS', 'TYPES_SITES', 'D', False, 'Supprimer des types de site'),
-                    ('MONITORINGS', 'GNM_SITES', 'R', False, 'Accéder aux sites'),
-                    ('MONITORINGS', 'GNM_SITES', 'C', False, 'Créer des sites'),
-                    ('MONITORINGS', 'GNM_SITES', 'U', False, 'Modifier des sites'),
-                    ('MONITORINGS', 'GNM_SITES', 'D', False, 'Supprimer des sites'),
-                    ('MONITORINGS', 'GNM_GRP_SITES', 'R', False, 'Accéder aux groupes de sites'),
-                    ('MONITORINGS', 'GNM_GRP_SITES', 'C', False, 'Créer des groupes de sites'),
-                    ('MONITORINGS', 'GNM_GRP_SITES', 'U', False, 'Modifier des groupes de sites'),
-                    ('MONITORINGS', 'GNM_GRP_SITES', 'D', False, 'Supprimer des groupes de sites')
+                    ('MONITORINGS', 'GNM_SITES', 'R', True, 'Accéder aux sites'),
+                    ('MONITORINGS', 'GNM_SITES', 'C', True, 'Créer des sites'),
+                    ('MONITORINGS', 'GNM_SITES', 'U', True, 'Modifier des sites'),
+                    ('MONITORINGS', 'GNM_SITES', 'D', True, 'Supprimer des sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'R', True, 'Accéder aux groupes de sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'C', True, 'Créer des groupes de sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'U', True, 'Modifier des groupes de sites'),
+                    ('MONITORINGS', 'GNM_GRP_SITES', 'D', True, 'Supprimer des groupes de sites')
             ) AS v (module_code, object_code, action_code, scope_filter, label)
         JOIN
             gn_commons.t_modules m ON m.module_code = v.module_code

--- a/backend/gn_module_monitoring/monitoring/admin.py
+++ b/backend/gn_module_monitoring/monitoring/admin.py
@@ -48,7 +48,7 @@ class BibTypeSiteView(CruvedProtectedMixin, ModelView):
     """
 
     module_code = "MONITORINGS"
-    object_code = None
+    object_code = "TYPES_SITES"
 
     def __init__(self, session, **kwargs):
         # Référence au model utilisé

--- a/backend/gn_module_monitoring/monitoring/base.py
+++ b/backend/gn_module_monitoring/monitoring/base.py
@@ -64,6 +64,7 @@ class MonitoringObjectBase:
     _model = None
     _children = {}
     _parent = None
+    cruved = {}
 
     def __init__(self, module_code, object_type, id=None, model=None):
         self._module_code = module_code

--- a/backend/gn_module_monitoring/monitoring/definitions.py
+++ b/backend/gn_module_monitoring/monitoring/definitions.py
@@ -40,7 +40,7 @@ MonitoringObjects_dict = {
 MonitoringPermissions_dict = {
     "site": "GNM_SITES",
     "sites_group": "GNM_GRP_SITES",
-    "visite": "GNM_VISITES",
+    "visit": "GNM_VISITES",
     "observation": "GNM_OBSERVATIONS",
     "module": "GNM_MODULES",
 }

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -91,6 +91,10 @@ class PermissionModel(GenericModel):
         for action_key , action_value in cruved_object.items():
             cruved_object_out[action_key] = self.has_instance_permission(scope=action_value)
         return cruved_object_out
+    def get_permission_by_action(self,module_code=None, object_code=None):
+       return  has_any_permissions_by_action(
+            module_code=module_code, object_code=object_code
+        )
      
 
 

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -32,7 +32,7 @@ from gn_module_monitoring.monitoring.queries import (
     Query as MonitoringQuery,
     SitesQuery,
     SitesGroupsQuery,
-    VisitQuery
+    VisitQuery,
 )
 from geonature.core.gn_permissions.tools import has_any_permissions_by_action
 
@@ -267,22 +267,20 @@ class TMonitoringVisits(TBaseVisits, PermissionModel):
             if self.digitiser.id_organisme is not None:
                 actors_organism_list.append(self.digitiser.id_organisme)
         return actors_organism_list
-    
+
     def has_instance_permission(self, scope):
         if scope == 0:
             return False
         elif scope in (1, 2):
             if (
                 g.current_user.id_role == self.id_digitiser
-                or  g.current_user.id_role in self.observers.id_role
+                or g.current_user.id_role in self.observers.id_role
             ):  # or g.current_user in self.user_actors:
                 return True
             if scope == 2 and g.current_user.organisme in self.organism_actors:
                 return True
         elif scope == 3:
             return True
-
-
 
 
 @geoserializable(geoCol="geom", idCol="id_base_site")
@@ -370,7 +368,6 @@ class TMonitoringSites(TBaseSites, PermissionModel):
             return True
 
 
-    
 @serializable
 class TMonitoringSitesGroups(DB.Model, PermissionModel):
     __tablename__ = "t_sites_groups"

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -2,7 +2,7 @@
     Modèles SQLAlchemy pour les modules de suivi
 """
 from flask import g
-from sqlalchemy import join, select, func, and_
+from sqlalchemy import join, select, func, and_, or_, false
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import (
     column_property,
@@ -254,25 +254,6 @@ class TMonitoringVisits(TBaseVisits, PermissionModel):
         foreign_keys=[TBaseVisits.id_module],
         uselist=False,
     )
-    # TODO: ca y est deja dans TBaseVisit (mais voir comment y accéder)
-    # digitiser = DB.relationship(
-    #     User, primaryjoin=(User.id_role == TBaseVisits.id_digitiser), foreign_keys=[TBaseVisits.id_digitiser]
-    # )
-
-    # observers = DB.relationship(
-    #     User,
-    #     secondary=corVisitObserver,
-    #     primaryjoin=(corVisitObserver.c.id_base_visit == id_base_visit),
-    #     secondaryjoin=(corVisitObserver.c.id_role == User.id_role),
-    #     foreign_keys=[corVisitObserver.c.id_base_visit, corVisitObserver.c.id_role],
-    # )
-
-    @hybrid_property
-    def observers_list(self):
-        # return self.digitiser.id_organisme
-        observers_list = []
-        observers_list.append(DB.session(self).query(corVisitObserver.id_role).filter(corVisitObserver.c.id_base_visit == self.id_base_visit).all())
-
 
     @hybrid_property
     def organism_actors(self):
@@ -285,7 +266,8 @@ class TMonitoringVisits(TBaseVisits, PermissionModel):
         else:
             if self.digitiser.id_organisme is not None:
                 actors_organism_list.append(self.digitiser.id_organisme)
-
+        return actors_organism_list
+    
     def has_instance_permission(self, scope):
         if scope == 0:
             return False
@@ -299,6 +281,8 @@ class TMonitoringVisits(TBaseVisits, PermissionModel):
                 return True
         elif scope == 3:
             return True
+
+
 
 
 @geoserializable(geoCol="geom", idCol="id_base_site")
@@ -386,6 +370,7 @@ class TMonitoringSites(TBaseSites, PermissionModel):
             return True
 
 
+    
 @serializable
 class TMonitoringSitesGroups(DB.Model, PermissionModel):
     __tablename__ = "t_sites_groups"

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -33,6 +33,7 @@ from gn_module_monitoring.monitoring.queries import (
     SitesQuery,
     SitesGroupsQuery,
 )
+from geonature.core.gn_permissions.tools import has_any_permissions_by_action
 
 
 class GenericModel:
@@ -82,6 +83,11 @@ class GenericModel:
         # ]
 
 
+class PermissionModel(GenericModel):
+    def has_permission(self, module_code, object_code):
+        return has_any_permissions_by_action(module_code=module_code, object_code=object_code)
+
+
 cor_module_type = DB.Table(
     "cor_module_type",
     DB.Column(
@@ -118,7 +124,7 @@ cor_type_site = DB.Table(
 
 
 @serializable
-class BibTypeSite(DB.Model, GenericModel):
+class BibTypeSite(DB.Model, PermissionModel):
     __tablename__ = "bib_type_site"
     __table_args__ = {"schema": "gn_monitoring"}
     query_class = MonitoringQuery
@@ -156,7 +162,7 @@ class TMonitoringObservationDetails(DB.Model):
 
 
 @serializable
-class TObservations(DB.Model):
+class TObservations(DB.Model, PermissionModel):
     __tablename__ = "t_observations"
     __table_args__ = {"schema": "gn_monitoring"}
 
@@ -182,7 +188,7 @@ class TObservations(DB.Model):
 
 
 @serializable
-class TMonitoringObservations(TObservations, GenericModel):
+class TMonitoringObservations(TObservations, PermissionModel):
     __tablename__ = "t_observation_complements"
     __table_args__ = {"schema": "gn_monitoring"}
     __mapper_args__ = {
@@ -202,7 +208,7 @@ TBaseVisits.dataset = DB.relationship(TDatasets)
 
 
 @serializable
-class TMonitoringVisits(TBaseVisits, GenericModel):
+class TMonitoringVisits(TBaseVisits, PermissionModel):
     __tablename__ = "t_visit_complements"
     __table_args__ = {"schema": "gn_monitoring"}
     __mapper_args__ = {
@@ -250,7 +256,7 @@ class TMonitoringVisits(TBaseVisits, GenericModel):
 
 
 @geoserializable(geoCol="geom", idCol="id_base_site")
-class TMonitoringSites(TBaseSites, GenericModel):
+class TMonitoringSites(TBaseSites, PermissionModel):
     __tablename__ = "t_site_complements"
     __table_args__ = {"schema": "gn_monitoring"}
     __mapper_args__ = {
@@ -335,7 +341,7 @@ class TMonitoringSites(TBaseSites, GenericModel):
 
 
 @serializable
-class TMonitoringSitesGroups(DB.Model, GenericModel):
+class TMonitoringSitesGroups(DB.Model, PermissionModel):
     __tablename__ = "t_sites_groups"
     __table_args__ = {"schema": "gn_monitoring"}
     query_class = SitesGroupsQuery
@@ -414,7 +420,7 @@ class TMonitoringSitesGroups(DB.Model, GenericModel):
 
 
 @serializable
-class TMonitoringModules(TModules):
+class TMonitoringModules(TModules, PermissionModel):
     __tablename__ = "t_module_complements"
     __table_args__ = {"schema": "gn_monitoring"}
     __mapper_args__ = {

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -33,6 +33,7 @@ from gn_module_monitoring.monitoring.queries import (
     SitesQuery,
     SitesGroupsQuery,
     VisitQuery,
+    ObservationsQuery,
 )
 from geonature.core.gn_permissions.tools import has_any_permissions_by_action
 
@@ -166,9 +167,13 @@ class TMonitoringObservationDetails(DB.Model):
 class TObservations(DB.Model, PermissionModel):
     __tablename__ = "t_observations"
     __table_args__ = {"schema": "gn_monitoring"}
-
+    query_class = ObservationsQuery
     id_observation = DB.Column(DB.Integer, primary_key=True, nullable=False, unique=True)
     id_base_visit = DB.Column(DB.ForeignKey("gn_monitoring.t_base_visits.id_base_visit"))
+    id_digitiser = DB.Column(DB.Integer, DB.ForeignKey("utilisateurs.t_roles.id_role"))
+    digitiser = DB.relationship(
+        User, primaryjoin=(User.id_role == id_digitiser), foreign_keys=[id_digitiser]
+    )
     cd_nom = DB.Column(DB.Integer)
     comments = DB.Column(DB.String)
     uuid_observation = DB.Column(UUID(as_uuid=True), default=uuid4)

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -5,6 +5,8 @@ from sqlalchemy.types import DateTime
 from werkzeug.datastructures import MultiDict
 from geonature.core.gn_permissions.tools import get_scopes_by_action
 import gn_module_monitoring.monitoring.models as Models
+
+
 class Query(BaseQuery):
     def _get_entity(self, entity):
         if hasattr(entity, "_entities"):
@@ -48,7 +50,7 @@ class Query(BaseQuery):
         )
         return cruved
 
-    def _get_read_scope(self, module_code="MONITORINGS",object_code=None, user=None):
+    def _get_read_scope(self, module_code="MONITORINGS", object_code=None, user=None):
         if user is None:
             user = g.current_user
         cruved = get_scopes_by_action(
@@ -56,11 +58,13 @@ class Query(BaseQuery):
         )
         return cruved["R"]
 
-    def filter_by_readable(self, module_code="MONITORINGS",object_code=None, user=None):
+    def filter_by_readable(self, module_code="MONITORINGS", object_code=None, user=None):
         """
         Return the object where the user has autorization via its CRUVED
         """
-        return self.filter_by_scope(self._get_read_scope(module_code=module_code, object_code=object_code, user=user))
+        return self.filter_by_scope(
+            self._get_read_scope(module_code=module_code, object_code=object_code, user=user)
+        )
 
 
 class SitesQuery(Query):
@@ -76,8 +80,10 @@ class SitesQuery(Query):
             ]
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
-                ors += [Models.TMonitoringSites.inventor.any(id_organisme=user.id_organisme),
-                       Models.TMonitoringSites.digitiser.any(id_organisme=user.id_organisme), ]
+                ors += [
+                    Models.TMonitoringSites.inventor.any(id_organisme=user.id_organisme),
+                    Models.TMonitoringSites.digitiser.any(id_organisme=user.id_organisme),
+                ]
             self = self.filter(or_(*ors))
         return self
 
@@ -94,7 +100,9 @@ class SitesGroupsQuery(Query):
             ]
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
-                ors += [Models.TMonitoringSitesGroups.digitiser.any(id_organisme=user.id_organisme)]
+                ors += [
+                    Models.TMonitoringSitesGroups.digitiser.any(id_organisme=user.id_organisme)
+                ]
             self = self.filter(or_(*ors))
         return self
 
@@ -109,14 +117,10 @@ class VisitQuery(Query):
         elif scope in (1, 2):
             ors = [
                 Models.TMonitoringVisits.id_digitiser == user.id_role,
-                Models.TMonitoringVisits.observers.any(id_role=user.id_role)
+                Models.TMonitoringVisits.observers.any(id_role=user.id_role),
             ]
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
-                ors += [
-                  Models.TMonitoringVisits.observers.any(id_organisme=user.id_organisme)
-                ]
+                ors += [Models.TMonitoringVisits.observers.any(id_organisme=user.id_organisme)]
             self = self.filter(or_(*ors))
         return self
-    
-

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -42,11 +42,11 @@ class Query(BaseQuery):
 
         return self.order_by(order_by)
 
-    def _get_cruved_scope(self, object_code, user=None):
+    def _get_cruved_scope(self, module_code=None,object_code=None, user=None):
         if user is None:
             user = g.current_user
         cruved = get_scopes_by_action(
-            id_role=user.id_role, module_code="MONITORINGS", object_code=object_code
+            id_role=user.id_role, module_code=module_code, object_code=object_code
         )
         return cruved
 
@@ -141,6 +141,6 @@ class ObservationsQuery(Query):
             ]
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
-                ors += [Models.TObservations.digitiser.any(id_organisme=user.id_organisme)]
+                ors += [Models.TObservations.digitiser.has(id_organisme=user.id_organisme)]
             self = self.filter(or_(*ors))
         return self

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -81,8 +81,8 @@ class SitesQuery(Query):
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
                 ors += [
-                    Models.TMonitoringSites.inventor.any(id_organisme=user.id_organisme),
-                    Models.TMonitoringSites.digitiser.any(id_organisme=user.id_organisme),
+                    Models.TMonitoringSites.inventor.has(id_organisme=user.id_organisme),
+                    Models.TMonitoringSites.digitiser.has(id_organisme=user.id_organisme),
                 ]
             self = self.filter(or_(*ors))
         return self
@@ -101,7 +101,7 @@ class SitesGroupsQuery(Query):
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
                 ors += [
-                    Models.TMonitoringSitesGroups.digitiser.any(id_organisme=user.id_organisme)
+                    Models.TMonitoringSitesGroups.digitiser.has(id_organisme=user.id_organisme)
                 ]
             self = self.filter(or_(*ors))
         return self
@@ -121,6 +121,26 @@ class VisitQuery(Query):
             ]
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
-                ors += [Models.TMonitoringVisits.observers.any(id_organisme=user.id_organisme)]
+                ors += [
+                    Models.TMonitoringVisits.observers.any(id_organisme=user.id_organisme),
+                    Models.TMonitoringVisits.digitiser.has(id_organisme=user.id_organisme),
+                ]
+            self = self.filter(or_(*ors))
+        return self
+
+
+class ObservationsQuery(Query):
+    def filter_by_scope(self, scope, user=None):
+        if user is None:
+            user = g.current_user
+        if scope == 0:
+            self = self.filter(false())
+        elif scope in (1, 2):
+            ors = [
+                Models.TObservations.id_digitiser == user.id_role,
+            ]
+            # if organism is None => do not filter on id_organism even if level = 2
+            if scope == 2 and user.id_organisme is not None:
+                ors += [Models.TObservations.digitiser.any(id_organisme=user.id_organisme)]
             self = self.filter(or_(*ors))
         return self

--- a/backend/gn_module_monitoring/monitoring/repositories.py
+++ b/backend/gn_module_monitoring/monitoring/repositories.py
@@ -7,6 +7,10 @@ import logging
 from ..utils.utils import to_int
 
 from sqlalchemy.orm import joinedload
+from gn_module_monitoring.utils.routes import (
+    get_objet_with_permission_boolean)
+from gn_module_monitoring.monitoring.models import PermissionModel, TMonitoringModules
+import gn_module_monitoring.monitoring.definitions as MonitoringDef
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +42,11 @@ class MonitoringObject(MonitoringObjectSerializer):
             self._model = req.filter(getattr(Model, field_name) == value).one()
 
             self._id = getattr(self._model, self.config_param("id_field_name"))
+            if isinstance(self._model,PermissionModel) and  not isinstance(self._model,TMonitoringModules):
+                cruved_item_dict = get_objet_with_permission_boolean([self._model], object_code=MonitoringDef.MonitoringPermissions_dict[self._object_type])
+                self.cruved = cruved_item_dict[0]['cruved']
+
+
 
             return self
 

--- a/backend/gn_module_monitoring/monitoring/schemas.py
+++ b/backend/gn_module_monitoring/monitoring/schemas.py
@@ -36,6 +36,10 @@ class MonitoringSitesGroupsSchema(MA.SQLAlchemyAutoSchema):
     medias = MA.Nested(MediaSchema, many=True)
     pk = fields.Method("set_pk", dump_only=True)
     geometry = fields.Method("serialize_geojson", dump_only=True)
+    id_digitiser = fields.Method("get_id_digitiser")
+
+    def get_id_digitiser(self, obj):
+        return obj.id_digitiser
 
     def set_pk(self, obj):
         return self.Meta.model.get_id()

--- a/backend/gn_module_monitoring/monitoring/schemas.py
+++ b/backend/gn_module_monitoring/monitoring/schemas.py
@@ -42,7 +42,7 @@ class MonitoringSitesGroupsSchema(MA.SQLAlchemyAutoSchema):
         return obj.id_digitiser
 
     def set_pk(self, obj):
-        return self.Meta.model.get_id()
+        return self.Meta.model.get_id_name()
 
     def serialize_geojson(self, obj):
         if obj.geom_geojson is not None:
@@ -80,7 +80,7 @@ class MonitoringSitesSchema(MA.SQLAlchemyAutoSchema):
             return geojson.dumps(obj.as_geofeature().get("geometry"))
 
     def set_pk(self, obj):
-        return self.Meta.model.get_id()
+        return self.Meta.model.get_id_name()
 
     def get_id_sites_group(self, obj):
         return obj.id_sites_group
@@ -101,4 +101,4 @@ class MonitoringVisitsSchema(MA.SQLAlchemyAutoSchema):
     module = MA.Nested(ModuleSchema)
 
     def set_pk(self, obj):
-        return self.Meta.model.get_id()
+        return self.Meta.model.get_id_name()

--- a/backend/gn_module_monitoring/monitoring/serializer.py
+++ b/backend/gn_module_monitoring/monitoring/serializer.py
@@ -62,7 +62,7 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
     def get_readable_list_object(self,relation_name,children_type):
         childs_model = getattr(self._model, relation_name)
         if isinstance(childs_model[0],PermissionModel) and not isinstance(childs_model[0],TMonitoringModules):
-            all_object_readable = childs_model[0].query.filter_by_readable(object_code=MonitoringDef.MonitoringPermissions_dict[children_type]).all()
+            all_object_readable = childs_model[0].query.filter_by_readable(module_code=self._module_code ,object_code=MonitoringDef.MonitoringPermissions_dict[children_type]).all()
             child_object_readable = [v for v in childs_model if v in all_object_readable]
             return child_object_readable
         return childs_model

--- a/backend/gn_module_monitoring/monitoring/serializer.py
+++ b/backend/gn_module_monitoring/monitoring/serializer.py
@@ -59,6 +59,14 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
         if data:
             properties["data"] = data
 
+    def get_readable_list_object(self,relation_name,children_type):
+        childs_model = getattr(self._model, relation_name)
+        if isinstance(childs_model[0],PermissionModel) and not isinstance(childs_model[0],TMonitoringModules):
+            all_object_readable = childs_model[0].query.filter_by_readable(object_code=MonitoringDef.MonitoringPermissions_dict[children_type]).all()
+            child_object_readable = [v for v in childs_model if v in all_object_readable]
+            return child_object_readable
+        return childs_model
+
     def serialize_children(self, depth):
         children_types = self.config_param("children_types")
 
@@ -76,7 +84,8 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
 
             children_of_type = []
 
-            for child_model in getattr(self._model, relation_name):
+            childs_object_readable = self.get_readable_list_object(relation_name,children_type=children_type)
+            for child_model in childs_object_readable:
                 child = monitoring_definitions.monitoring_object_instance(
                     self._module_code, children_type, model=child_model
                 )

--- a/backend/gn_module_monitoring/monitoring/serializer.py
+++ b/backend/gn_module_monitoring/monitoring/serializer.py
@@ -61,7 +61,7 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
 
     def get_readable_list_object(self,relation_name,children_type):
         childs_model = getattr(self._model, relation_name)
-        if isinstance(childs_model[0],PermissionModel) and not isinstance(childs_model[0],TMonitoringModules):
+        if len(childs_model)>0 and isinstance(childs_model[0],PermissionModel) and not isinstance(childs_model[0],TMonitoringModules):
             all_object_readable = childs_model[0].query.filter_by_readable(module_code=self._module_code ,object_code=MonitoringDef.MonitoringPermissions_dict[children_type]).all()
             child_object_readable = [v for v in childs_model if v in all_object_readable]
             return child_object_readable

--- a/backend/gn_module_monitoring/routes/modules.py
+++ b/backend/gn_module_monitoring/routes/modules.py
@@ -8,7 +8,7 @@ from utils_flask_sqla.response import json_resp_accept_empty_list, json_resp
 from ..blueprint import blueprint
 from ..utils.utils import to_int
 
-from geonature.core.gn_permissions.tools import get_scopes_by_action
+from geonature.core.gn_permissions.tools import get_scopes_by_action, has_any_permissions_by_action
 from geonature.core.gn_permissions.decorators import check_cruved_scope
 
 from gn_module_monitoring.monitoring.schemas import BibTypeSiteSchema
@@ -58,7 +58,7 @@ def get_cruved_monitorings():
     object_list_tuples = get_object_list_monitorings()
     object_list = [value for (value,) in object_list_tuples]
     for object in object_list:
-        dic_object_cruved[object] = get_scopes_by_action(
+        dic_object_cruved[object] = has_any_permissions_by_action(
             module_code=MODULE_CODE, object_code=object
         )
 

--- a/backend/gn_module_monitoring/routes/modules.py
+++ b/backend/gn_module_monitoring/routes/modules.py
@@ -19,7 +19,10 @@ from ..modules.repositories import (
     get_modules,
 )
 from ..config.repositories import get_config
-from gn_module_monitoring.utils.routes import query_all_types_site_from_module_id
+from gn_module_monitoring.utils.routes import (
+    query_all_types_site_from_module_id,
+    get_object_list_monitorings,
+)
 
 
 @blueprint.route("/module/<value>", methods=["GET"])
@@ -43,6 +46,23 @@ def get_module_api(value):
         module_out["cruved"] = get_scopes_by_action(module_code=module.module_code)
 
     return module_out
+
+
+@blueprint.route("/cruved_object", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE)
+def get_cruved_monitorings():
+    """
+    Renvoie la liste des modules de suivi
+    """
+    dic_object_cruved = {}
+    object_list_tuples = get_object_list_monitorings()
+    object_list = [value for (value,) in object_list_tuples]
+    for object in object_list:
+        dic_object_cruved[object] = get_scopes_by_action(
+            module_code=MODULE_CODE, object_code=object
+        )
+
+    return dic_object_cruved
 
 
 @blueprint.route("/modules", methods=["GET"])

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -122,7 +122,7 @@ def get_sites(object_type):
 
     query_allowed = query.filter_by_readable(object_code=object_code)
     return paginate_scope(
-        query=query_allowed, schema=MonitoringSitesSchema, limit=limit, page=page
+        query=query_allowed, schema=MonitoringSitesSchema, limit=limit, page=page,object_code=object_code
     )
     # return paginate(
     #     query=query,

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -98,10 +98,8 @@ def get_type_site_by_id(id_type_site):
     return schema.dump(res)
 
 
-@blueprint.route(
-    "/sites/<int:id_site>/types", methods=["GET"], defaults={"id": None, "object_type": "site"}
-)
-def get_all_types_site_from_site_id(id_site):
+@blueprint.route("/sites/<int:id_site>/types", methods=["GET"], defaults={"object_type": "site"})
+def get_all_types_site_from_site_id(id_site, object_type):
     types_site = query_all_types_site_from_site_id(id_site)
     schema = BibTypeSiteSchema()
     return [schema.dump(res) for res in types_site]

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -16,7 +16,8 @@ from gn_module_monitoring.monitoring.models import (
     TMonitoringSites,
     TNomenclatures,
 )
-
+from gn_module_monitoring import MODULE_CODE
+from geonature.core.gn_permissions.decorators import check_cruved_scope
 from gn_module_monitoring.monitoring.schemas import BibTypeSiteSchema, MonitoringSitesSchema
 from gn_module_monitoring.routes.monitoring import (
     create_or_update_object_api_sites_sites_group,
@@ -99,6 +100,7 @@ def get_all_types_site_from_site_id(id_site):
 
 
 @blueprint.route("/sites", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_SITES")
 def get_sites():
     params = MultiDict(request.args)
     # TODO: add filter support
@@ -120,6 +122,7 @@ def get_sites():
 
 
 @blueprint.route("/sites/<int:id_base_site>", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_SITES")
 def get_site_by_id(id_base_site):
     site = TMonitoringSites.query.get_or_404(id_base_site)
     schema = MonitoringSitesSchema()
@@ -129,6 +132,7 @@ def get_site_by_id(id_base_site):
 
 
 @blueprint.route("/sites/geometries", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_SITES")
 def get_all_site_geometries():
     params = MultiDict(request.args)
     subquery = (
@@ -168,6 +172,7 @@ def get_module_sites(module_code: str):
 
 
 @blueprint.route("/sites", methods=["POST"])
+@check_cruved_scope("C", module_code=MODULE_CODE, object_code="GNM_SITES")
 def post_sites():
     module_code = "generic"
     object_type = "site"
@@ -183,6 +188,7 @@ def post_sites():
 
 
 @blueprint.route("/sites/<int:_id>", methods=["DELETE"])
+@check_cruved_scope("D", module_code=MODULE_CODE, object_code="GNM_SITES")
 def delete_site(_id):
     TMonitoringSites.query.filter_by(id_g=_id).delete()
     db.session.commit()
@@ -190,6 +196,7 @@ def delete_site(_id):
 
 
 @blueprint.route("/sites/<int:_id>", methods=["PATCH"])
+@check_cruved_scope("U", module_code=MODULE_CODE, object_code="GNM_SITES")
 def patch_sites(_id):
     module_code = "generic"
     object_type = "site"

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -150,9 +150,12 @@ def get_site_by_id(scope, id_base_site):
 @blueprint.route("/sites/geometries", methods=["GET"])
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_SITES")
 def get_all_site_geometries():
+    object_code = "GNM_SITES"
     params = MultiDict(request.args)
+    query = TMonitoringSites.query
+    query_allowed = query.filter_by_readable(object_code=object_code)
     subquery = (
-        TMonitoringSites.query.with_entities(
+        query_allowed.with_entities(
             TMonitoringSites.id_base_site,
             TMonitoringSites.base_site_name,
             TMonitoringSites.geom,

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -142,6 +142,7 @@ def get_site_by_id(scope, id, object_type):
         raise Forbidden(f"User {g.current_user} cannot read site {site.id_base_site}")
     schema = MonitoringSitesSchema()
     response = schema.dump(site)
+    response['cruved']=get_objet_with_permission_boolean([site], object_code="GNM_SITES")[0]['cruved']
     response["geometry"] = json.loads(response["geometry"])
     return response
 

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -98,14 +98,16 @@ def get_type_site_by_id(id_type_site):
     return schema.dump(res)
 
 
-@blueprint.route("/sites/<int:id_site>/types", methods=["GET"],defaults={"id": None, "object_type":"site"})
+@blueprint.route(
+    "/sites/<int:id_site>/types", methods=["GET"], defaults={"id": None, "object_type": "site"}
+)
 def get_all_types_site_from_site_id(id_site):
     types_site = query_all_types_site_from_site_id(id_site)
     schema = BibTypeSiteSchema()
     return [schema.dump(res) for res in types_site]
 
 
-@blueprint.route("/sites", methods=["GET"],defaults={"object_type":"site"})
+@blueprint.route("/sites", methods=["GET"], defaults={"object_type": "site"})
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_SITES")
 def get_sites(object_type):
     object_code = "GNM_SITES"
@@ -122,10 +124,7 @@ def get_sites(object_type):
 
     query_allowed = query.filter_by_readable(object_code=object_code)
     return paginate_scope(
-        query=query_allowed,
-        schema=MonitoringSitesSchema,
-        limit=limit,
-        page=page
+        query=query_allowed, schema=MonitoringSitesSchema, limit=limit, page=page
     )
     # return paginate(
     #     query=query,
@@ -135,11 +134,11 @@ def get_sites(object_type):
     # )
 
 
-@blueprint.route("/sites/<int:id>", methods=["GET"],defaults={"object_type":"site"})
+@blueprint.route("/sites/<int:id>", methods=["GET"], defaults={"object_type": "site"})
 @permissions.check_cruved_scope(
     "R", get_scope=True, module_code=MODULE_CODE, object_code="GNM_SITES"
 )
-def get_site_by_id(scope,id, object_type):
+def get_site_by_id(scope, id, object_type):
     site = TMonitoringSites.query.get_or_404(id)
     if not site.has_instance_permission(scope=scope):
         raise Forbidden(f"User {g.current_user} cannot read site {site.id_base_site}")
@@ -149,7 +148,7 @@ def get_site_by_id(scope,id, object_type):
     return response
 
 
-@blueprint.route("/sites/geometries", methods=["GET"],defaults={"object_type":"site"})
+@blueprint.route("/sites/geometries", methods=["GET"], defaults={"object_type": "site"})
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_SITES")
 def get_all_site_geometries(object_type):
     object_code = "GNM_SITES"
@@ -201,7 +200,7 @@ def get_module_sites(module_code: str):
     return jsonify({"module_code": module_code})
 
 
-@blueprint.route("/sites", methods=["POST"],defaults={"object_type":"site"})
+@blueprint.route("/sites", methods=["POST"], defaults={"object_type": "site"})
 @check_cruved_scope("C", module_code=MODULE_CODE, object_code="GNM_SITES")
 def post_sites(object_type):
     module_code = "generic"
@@ -217,7 +216,7 @@ def post_sites(object_type):
     return create_or_update_object_api_sites_sites_group(module_code, object_type), 201
 
 
-@blueprint.route("/sites/<int:_id>", methods=["DELETE"],defaults={"object_type":"site"})
+@blueprint.route("/sites/<int:_id>", methods=["DELETE"], defaults={"object_type": "site"})
 @permissions.check_cruved_scope(
     "D", get_scope=True, module_code=MODULE_CODE, object_code="GNM_SITES"
 )
@@ -230,7 +229,7 @@ def delete_site(scope, _id, object_type):
     return {"success": "Item is successfully deleted"}, 200
 
 
-@blueprint.route("/sites/<int:_id>", methods=["PATCH"],defaults={"object_type":"site"})
+@blueprint.route("/sites/<int:_id>", methods=["PATCH"], defaults={"object_type": "site"})
 @permissions.check_cruved_scope(
     "U", get_scope=True, module_code=MODULE_CODE, object_code="GNM_SITES"
 )

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -35,9 +35,9 @@ def get_config_sites_groups(id=None, module_code="generic", object_type="sites_g
     return obj["properties"]
 
 
-@blueprint.route("/sites_groups", methods=["GET"])
+@blueprint.route("/sites_groups", methods=["GET"],defaults={"object_type":"sites_group"})
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def get_sites_groups():
+def get_sites_groups(object_type:str):
     object_code = "GNM_GRP_SITES"
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
@@ -53,8 +53,7 @@ def get_sites_groups():
         query=query_allowed,
         schema=MonitoringSitesGroupsSchema,
         limit=limit,
-        page=page,
-        object_code=object_code,
+        page=page
     )
     # return paginate(
     #     query=query,
@@ -64,17 +63,17 @@ def get_sites_groups():
     # )
 
 
-@blueprint.route("/sites_groups/<int:id_sites_group>", methods=["GET"])
+@blueprint.route("/sites_groups/<int:id_sites_group>", methods=["GET"], defaults={"object_type":"sites_group"})
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def get_sites_group_by_id(id_sites_group: int):
+def get_sites_group_by_id(id_sites_group: int,object_type:str):
     schema = MonitoringSitesGroupsSchema()
     result = TMonitoringSitesGroups.query.get_or_404(id_sites_group)
     return jsonify(schema.dump(result))
 
 
-@blueprint.route("/sites_groups/geometries", methods=["GET"])
+@blueprint.route("/sites_groups/geometries", methods=["GET"], defaults={"object_type":"sites_group"})
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def get_sites_group_geometries():
+def get_sites_group_geometries(object_type:str):
     object_code = "GNM_GRP_SITES"
     query = TMonitoringSitesGroups.query
     query_allowed = query.filter_by_readable(object_code=object_code)
@@ -97,20 +96,19 @@ def get_sites_group_geometries():
     return jsonify(result)
 
 
-@blueprint.route("/sites_groups/<int:_id>", methods=["PATCH"])
+@blueprint.route("/sites_groups/<int:_id>", methods=["PATCH"],defaults={"object_type":"sites_group"})
 @check_cruved_scope("U", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def patch(_id):
+def patch(_id:int, object_type:str):
     # ###############################""
     # FROM route/monitorings
     module_code = "generic"
-    object_type = "sites_group"
     get_config(module_code, force=True)
     return create_or_update_object_api_sites_sites_group(module_code, object_type, _id), 201
 
 
-@blueprint.route("/sites_groups/<int:_id>", methods=["DELETE"])
+@blueprint.route("/sites_groups/<int:_id>", methods=["DELETE"], defaults={"object_type":"sites_group"})
 @check_cruved_scope("D", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def delete(_id):
+def delete(_id:int, object_type:str):
     item_schema = MonitoringSitesGroupsSchema()
     item = TMonitoringSitesGroups.find_by_id(_id)
     TMonitoringSitesGroups.query.filter_by(id_g=_id).delete()
@@ -118,11 +116,10 @@ def delete(_id):
     return item_schema.dump(item), 201
 
 
-@blueprint.route("/sites_groups", methods=["POST"])
+@blueprint.route("/sites_groups", methods=["POST"], defaults={"object_type":"sites_group"})
 @check_cruved_scope("P", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def post():
+def post(object_type:str):
     module_code = "generic"
-    object_type = "sites_group"
     get_config(module_code, force=True)
     return create_or_update_object_api_sites_sites_group(module_code, object_type), 201
 

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -19,6 +19,7 @@ from gn_module_monitoring.utils.routes import (
     get_limit_page,
     get_sort,
     paginate,
+    paginate_scope,
     sort,
 )
 from gn_module_monitoring.routes.monitoring import (
@@ -37,6 +38,7 @@ def get_config_sites_groups(id=None, module_code="generic", object_type="sites_g
 @blueprint.route("/sites_groups", methods=["GET"])
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def get_sites_groups():
+    object_code = "GNM_GRP_SITES"
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
     sort_label, sort_dir = get_sort(
@@ -45,12 +47,21 @@ def get_sites_groups():
     query = filter_params(query=TMonitoringSitesGroups.query, params=params)
 
     query = sort(query=query, sort=sort_label, sort_dir=sort_dir)
-    return paginate(
-        query=query,
+
+    query_allowed = query.filter_by_readable(object_code=object_code)
+    return paginate_scope(
+        query=query_allowed,
         schema=MonitoringSitesGroupsSchema,
         limit=limit,
         page=page,
+        object_code=object_code,
     )
+    # return paginate(
+    #     query=query,
+    #     schema=MonitoringSitesGroupsSchema,
+    #     limit=limit,
+    #     page=page,
+    # )
 
 
 @blueprint.route("/sites_groups/<int:id_sites_group>", methods=["GET"])

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -75,8 +75,11 @@ def get_sites_group_by_id(id_sites_group: int):
 @blueprint.route("/sites_groups/geometries", methods=["GET"])
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def get_sites_group_geometries():
+    object_code = "GNM_GRP_SITES"
+    query = TMonitoringSitesGroups.query
+    query_allowed = query.filter_by_readable(object_code=object_code)
     subquery = (
-        db.session.query(
+        query_allowed.with_entities(
             TMonitoringSitesGroups.id_sites_group,
             TMonitoringSitesGroups.sites_group_name,
             func.st_convexHull(func.st_collect(TMonitoringSites.geom)),

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -8,6 +8,8 @@ from gn_module_monitoring.blueprint import blueprint
 from gn_module_monitoring.config.repositories import get_config
 from gn_module_monitoring.modules.repositories import get_module
 from gn_module_monitoring.monitoring.definitions import monitoring_definitions
+from gn_module_monitoring import MODULE_CODE
+from geonature.core.gn_permissions.decorators import check_cruved_scope
 from gn_module_monitoring.monitoring.models import TMonitoringSites, TMonitoringSitesGroups
 from gn_module_monitoring.monitoring.schemas import MonitoringSitesGroupsSchema
 from gn_module_monitoring.utils.errors.errorHandler import InvalidUsage
@@ -33,6 +35,7 @@ def get_config_sites_groups(id=None, module_code="generic", object_type="sites_g
 
 
 @blueprint.route("/sites_groups", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def get_sites_groups():
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
@@ -51,6 +54,7 @@ def get_sites_groups():
 
 
 @blueprint.route("/sites_groups/<int:id_sites_group>", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def get_sites_group_by_id(id_sites_group: int):
     schema = MonitoringSitesGroupsSchema()
     result = TMonitoringSitesGroups.query.get_or_404(id_sites_group)
@@ -58,6 +62,7 @@ def get_sites_group_by_id(id_sites_group: int):
 
 
 @blueprint.route("/sites_groups/geometries", methods=["GET"])
+@check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def get_sites_group_geometries():
     subquery = (
         db.session.query(
@@ -79,6 +84,7 @@ def get_sites_group_geometries():
 
 
 @blueprint.route("/sites_groups/<int:_id>", methods=["PATCH"])
+@check_cruved_scope("U", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def patch(_id):
     # ###############################""
     # FROM route/monitorings
@@ -89,6 +95,7 @@ def patch(_id):
 
 
 @blueprint.route("/sites_groups/<int:_id>", methods=["DELETE"])
+@check_cruved_scope("D", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def delete(_id):
     item_schema = MonitoringSitesGroupsSchema()
     item = TMonitoringSitesGroups.find_by_id(_id)
@@ -98,6 +105,7 @@ def delete(_id):
 
 
 @blueprint.route("/sites_groups", methods=["POST"])
+@check_cruved_scope("P", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
 def post():
     module_code = "generic"
     object_type = "sites_group"

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -35,9 +35,9 @@ def get_config_sites_groups(id=None, module_code="generic", object_type="sites_g
     return obj["properties"]
 
 
-@blueprint.route("/sites_groups", methods=["GET"],defaults={"object_type":"sites_group"})
+@blueprint.route("/sites_groups", methods=["GET"], defaults={"object_type": "sites_group"})
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def get_sites_groups(object_type:str):
+def get_sites_groups(object_type: str):
     object_code = "GNM_GRP_SITES"
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
@@ -50,10 +50,7 @@ def get_sites_groups(object_type:str):
 
     query_allowed = query.filter_by_readable(object_code=object_code)
     return paginate_scope(
-        query=query_allowed,
-        schema=MonitoringSitesGroupsSchema,
-        limit=limit,
-        page=page
+        query=query_allowed, schema=MonitoringSitesGroupsSchema, limit=limit, page=page
     )
     # return paginate(
     #     query=query,
@@ -63,17 +60,21 @@ def get_sites_groups(object_type:str):
     # )
 
 
-@blueprint.route("/sites_groups/<int:id_sites_group>", methods=["GET"], defaults={"object_type":"sites_group"})
+@blueprint.route(
+    "/sites_groups/<int:id_sites_group>", methods=["GET"], defaults={"object_type": "sites_group"}
+)
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def get_sites_group_by_id(id_sites_group: int,object_type:str):
+def get_sites_group_by_id(id_sites_group: int, object_type: str):
     schema = MonitoringSitesGroupsSchema()
     result = TMonitoringSitesGroups.query.get_or_404(id_sites_group)
     return jsonify(schema.dump(result))
 
 
-@blueprint.route("/sites_groups/geometries", methods=["GET"], defaults={"object_type":"sites_group"})
+@blueprint.route(
+    "/sites_groups/geometries", methods=["GET"], defaults={"object_type": "sites_group"}
+)
 @check_cruved_scope("R", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def get_sites_group_geometries(object_type:str):
+def get_sites_group_geometries(object_type: str):
     object_code = "GNM_GRP_SITES"
     query = TMonitoringSitesGroups.query
     query_allowed = query.filter_by_readable(object_code=object_code)
@@ -96,9 +97,11 @@ def get_sites_group_geometries(object_type:str):
     return jsonify(result)
 
 
-@blueprint.route("/sites_groups/<int:_id>", methods=["PATCH"],defaults={"object_type":"sites_group"})
+@blueprint.route(
+    "/sites_groups/<int:_id>", methods=["PATCH"], defaults={"object_type": "sites_group"}
+)
 @check_cruved_scope("U", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def patch(_id:int, object_type:str):
+def patch(_id: int, object_type: str):
     # ###############################""
     # FROM route/monitorings
     module_code = "generic"
@@ -106,9 +109,11 @@ def patch(_id:int, object_type:str):
     return create_or_update_object_api_sites_sites_group(module_code, object_type, _id), 201
 
 
-@blueprint.route("/sites_groups/<int:_id>", methods=["DELETE"], defaults={"object_type":"sites_group"})
+@blueprint.route(
+    "/sites_groups/<int:_id>", methods=["DELETE"], defaults={"object_type": "sites_group"}
+)
 @check_cruved_scope("D", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def delete(_id:int, object_type:str):
+def delete(_id: int, object_type: str):
     item_schema = MonitoringSitesGroupsSchema()
     item = TMonitoringSitesGroups.find_by_id(_id)
     TMonitoringSitesGroups.query.filter_by(id_g=_id).delete()
@@ -116,9 +121,9 @@ def delete(_id:int, object_type:str):
     return item_schema.dump(item), 201
 
 
-@blueprint.route("/sites_groups", methods=["POST"], defaults={"object_type":"sites_group"})
+@blueprint.route("/sites_groups", methods=["POST"], defaults={"object_type": "sites_group"})
 @check_cruved_scope("P", module_code=MODULE_CODE, object_code="GNM_GRP_SITES")
-def post(object_type:str):
+def post(object_type: str):
     module_code = "generic"
     get_config(module_code, force=True)
     return create_or_update_object_api_sites_sites_group(module_code, object_type), 201

--- a/backend/gn_module_monitoring/routes/visit.py
+++ b/backend/gn_module_monitoring/routes/visit.py
@@ -12,14 +12,16 @@ from gn_module_monitoring.utils.routes import (
     paginate,
     paginate_scope,
     sort,
-    get_objet_with_permission_boolean
+    get_objet_with_permission_boolean,
 )
 from gn_module_monitoring.routes.modules import get_modules
 from gn_module_monitoring.monitoring.definitions import MonitoringPermissions_dict
-# Retrieves visits that do not depend on modules
-OBJECT_CODE= MonitoringPermissions_dict["visite"]
 
-@blueprint.route("/visits", methods=["GET"],defaults={"object_type":"visite"})
+# Retrieves visits that do not depend on modules
+OBJECT_CODE = MonitoringPermissions_dict["visite"]
+
+
+@blueprint.route("/visits", methods=["GET"], defaults={"object_type": "visite"})
 def get_visits(object_type):
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
@@ -27,20 +29,24 @@ def get_visits(object_type):
         params=params, default_sort="id_base_visit", default_direction="desc"
     )
     modules_object = get_modules()
-    modules = get_objet_with_permission_boolean(modules_object,object_code=OBJECT_CODE)
+    modules = get_objet_with_permission_boolean(modules_object, object_code=OBJECT_CODE)
     ids_modules_allowed = [module["id_module"] for module in modules if module["cruved"]["R"]]
-    query =  TMonitoringVisits.query
-    query = query.options(joinedload(TMonitoringVisits.module)).filter(TMonitoringVisits.id_module.in_(ids_modules_allowed))
+    query = TMonitoringVisits.query
+    query = query.options(joinedload(TMonitoringVisits.module)).filter(
+        TMonitoringVisits.id_module.in_(ids_modules_allowed)
+    )
     query = filter_params(query=query, params=params)
     query = sort(query=query, sort=sort_label, sort_dir=sort_dir)
     query_allowed = query
     for module in modules:
         if module["id_module"] in ids_modules_allowed:
-            query_allowed = query_allowed.filter_by_readable(module_code=module['module_code'],object_code=OBJECT_CODE)
+            query_allowed = query_allowed.filter_by_readable(
+                module_code=module["module_code"], object_code=OBJECT_CODE
+            )
     return paginate_scope(
         query=query_allowed,
         schema=MonitoringVisitsSchema,
         limit=limit,
         page=page,
-        object_code=OBJECT_CODE
+        object_code=OBJECT_CODE,
     )

--- a/backend/gn_module_monitoring/routes/visit.py
+++ b/backend/gn_module_monitoring/routes/visit.py
@@ -10,26 +10,35 @@ from gn_module_monitoring.utils.routes import (
     get_limit_page,
     get_sort,
     paginate,
+    paginate_scope,
     sort,
+    get_objet_with_permission_boolean
 )
-
+from gn_module_monitoring.routes.modules import get_modules
+from gn_module_monitoring.monitoring.definitions import MonitoringPermissions_dict
 # Retrieves visits that do not depend on modules
+OBJECT_CODE= MonitoringPermissions_dict["visite"]
 
-
-@blueprint.route("/visits", methods=["GET"])
-def get_visits():
+@blueprint.route("/visits", methods=["GET"],defaults={"object_type":"visite"})
+def get_visits(object_type):
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
     sort_label, sort_dir = get_sort(
         params=params, default_sort="id_base_visit", default_direction="desc"
     )
-    query = TMonitoringVisits.query.options(joinedload(TMonitoringVisits.module))
+    modules_object = get_modules()
+    modules = get_objet_with_permission_boolean(modules_object,object_code=OBJECT_CODE)
+    ids_modules_allowed = [module["id_module"] for module in modules if module["cruved"]["R"]]
+    query = TMonitoringVisits.query.options(joinedload(TMonitoringVisits.module)).filter(TMonitoringVisits.id_module.in_(ids_modules_allowed))
     query = filter_params(query=query, params=params)
     query = sort(query=query, sort=sort_label, sort_dir=sort_dir)
-
-    return paginate(
-        query=query,
+    query_allowed = query
+    for module in modules:
+        if module["id_module"] in ids_modules_allowed:
+            query_allowed = query_allowed.filter_by_readable(module_code=module['module_code'],object_code=OBJECT_CODE)
+    return paginate_scope(
+        query=query_allowed,
         schema=MonitoringVisitsSchema,
         limit=limit,
-        page=page,
+        page=page
     )

--- a/backend/gn_module_monitoring/routes/visit.py
+++ b/backend/gn_module_monitoring/routes/visit.py
@@ -29,7 +29,8 @@ def get_visits(object_type):
     modules_object = get_modules()
     modules = get_objet_with_permission_boolean(modules_object,object_code=OBJECT_CODE)
     ids_modules_allowed = [module["id_module"] for module in modules if module["cruved"]["R"]]
-    query = TMonitoringVisits.query.options(joinedload(TMonitoringVisits.module)).filter(TMonitoringVisits.id_module.in_(ids_modules_allowed))
+    query =  TMonitoringVisits.query
+    query = query.options(joinedload(TMonitoringVisits.module)).filter(TMonitoringVisits.id_module.in_(ids_modules_allowed))
     query = filter_params(query=query, params=params)
     query = sort(query=query, sort=sort_label, sort_dir=sort_dir)
     query_allowed = query
@@ -40,5 +41,6 @@ def get_visits(object_type):
         query=query_allowed,
         schema=MonitoringVisitsSchema,
         limit=limit,
-        page=page
+        page=page,
+        object_code=OBJECT_CODE
     )

--- a/backend/gn_module_monitoring/routes/visit.py
+++ b/backend/gn_module_monitoring/routes/visit.py
@@ -18,10 +18,10 @@ from gn_module_monitoring.routes.modules import get_modules
 from gn_module_monitoring.monitoring.definitions import MonitoringPermissions_dict
 
 # Retrieves visits that do not depend on modules
-OBJECT_CODE = MonitoringPermissions_dict["visite"]
+OBJECT_CODE = MonitoringPermissions_dict["visit"]
 
 
-@blueprint.route("/visits", methods=["GET"], defaults={"object_type": "visite"})
+@blueprint.route("/visits", methods=["GET"], defaults={"object_type": "visit"})
 def get_visits(object_type):
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -210,11 +210,7 @@ def get_objet_with_permission_boolean(objects, depth: int = 0, module_code=None,
         cruved_object = object.query._get_cruved_scope(object_code=object_code)
         object_out = object.as_dict(depth=depth)
         if hasattr(object, "module_code"):
-            object_out["cruved"] = object.has_permission(cruved_object=cruved_object
-            )
-        elif hasattr(object, "module") and hasattr(object.module, "module_code"):
-            object_out["cruved"] = object.has_permission(cruved_object=cruved_object
-            )
+            object_out["cruved"] = object.get_permission_by_action(module_code=object.module_code,object_code=object_code)
         else:
             object_out["cruved"] = object.has_permission(
                 cruved_object=cruved_object

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -202,22 +202,22 @@ def get_object_list_monitorings():
         raise GeoNatureError("MONITORINGS - get_object_list_monitorings : {}".format(str(e)))
 
 
-def get_objet_with_permission_boolean(objects, depth: int = 0, module_code=None, object_code=None):
+def get_objet_with_permission_boolean(objects, depth: int = 0, module_code=None, object_code=None, id_role=None):
+    if id_role is None:
+       id_role =  g.current_user.id_role
     objects_out = []
     for object in objects:
+        cruved_object = object.query._get_cruved_scope(object_code=object_code)
         object_out = object.as_dict(depth=depth)
         if hasattr(object, "module_code"):
-            object_out["cruved"] = object.has_permission(
-                module_code=object.module_code, object_code=object_code
+            object_out["cruved"] = object.has_permission(cruved_object=cruved_object
             )
         elif hasattr(object, "module") and hasattr(object.module, "module_code"):
-            # set_permission_global_session(object.module.module_code,object_type)
-            object_out["cruved"] = object.has_permission(
-                module_code=object.module.module_code, object_code=object_code
+            object_out["cruved"] = object.has_permission(cruved_object=cruved_object
             )
         else:
             object_out["cruved"] = object.has_permission(
-                module_code=module_code, object_code=object_code
+                cruved_object=cruved_object
             )
         objects_out.append(object_out)
 

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -52,6 +52,7 @@ def paginate_scope(
     datas_allowed = pagination_schema().dump(
         dict(items=result.items, count=result.total, limit=limit, page=page)
     )
+    # TODO: améliorer cette partie --> voir la méthode get_objet_with_permission_boolean
     cruved_item_dict = {}
     cruved_items = [
         (item.id_g, item.query._get_cruved_scope(object_code=object_code)) for item in result.items
@@ -218,3 +219,20 @@ def get_object_list_monitorings():
         return object_list_monitorings
     except Exception as e:
         raise GeoNatureError("MONITORINGS - get_object_list_monitorings : {}".format(str(e)))
+
+
+def get_objet_with_permission_boolean(objects, depth: int = 0, module_code=None, object_code=None):
+    objects_out = []
+    for object in objects:
+        object_out = object.as_dict(depth=depth)
+        if hasattr(object, "module_code"):
+            object_out["cruved"] = object.has_permission(
+                module_code=object.module_code, object_code=object_code
+            )
+        else:
+            object_out["cruved"] = object.has_permission(
+                module_code=module_code, object_code=object_code
+            )
+        objects_out.append(object_out)
+
+    return objects_out

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -26,6 +26,7 @@ from werkzeug.datastructures import MultiDict
 from gn_module_monitoring.monitoring.queries import Query as MonitoringQuery
 from gn_module_monitoring.monitoring.schemas import paginate_schema
 
+
 def get_limit_page(params: MultiDict) -> Tuple[int]:
     return int(params.pop("limit", 50)), int(params.pop("page", 1))
 
@@ -51,7 +52,7 @@ def paginate_scope(
     datas_allowed = pagination_schema().dump(
         dict(items=result.items, count=result.total, limit=limit, page=page)
     )
-    cruved_item_dict = get_objet_with_permission_boolean(result.items,object_code=object_code)
+    cruved_item_dict = get_objet_with_permission_boolean(result.items, object_code=object_code)
     for cruved_item in cruved_item_dict:
         for i, data in enumerate(datas_allowed["items"]):
             if data[data["pk"]] == cruved_item[data["pk"]]:
@@ -213,7 +214,7 @@ def get_objet_with_permission_boolean(objects, depth: int = 0, module_code=None,
             # set_permission_global_session(object.module.module_code,object_type)
             object_out["cruved"] = object.has_permission(
                 module_code=object.module.module_code, object_code=object_code
-            )          
+            )
         else:
             object_out["cruved"] = object.has_permission(
                 module_code=module_code, object_code=object_code
@@ -221,6 +222,7 @@ def get_objet_with_permission_boolean(objects, depth: int = 0, module_code=None,
         objects_out.append(object_out)
 
     return objects_out
+
 
 # from gn_module_monitoring.monitoring.definitions import MonitoringPermissions_dict
 # from gn_module_monitoring import MODULE_CODE

--- a/frontend/app/class/monitoring-object-base.ts
+++ b/frontend/app/class/monitoring-object-base.ts
@@ -3,16 +3,14 @@ import { Utils } from '../utils/utils';
 import { Observable, of } from 'rxjs';
 import { forkJoin } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
-import { threadId } from 'worker_threads';
-
 export class MonitoringObjectBase {
   moduleCode: string;
   objectType: string;
   id: number; // id de l'objet
-
+  cruved:Object;
   parentsPath = [];
 
-  userCruved;
+
   userCruvedObject;
   deleted = false;
 
@@ -124,7 +122,6 @@ export class MonitoringObjectBase {
   }
 
   setData(data) {
-    this.userCruved = data.cruved;
     this.userCruvedObject = data.cruved_objects;
     this.properties = data.properties || {};
     this.geometry = data.geometry;
@@ -132,6 +129,7 @@ export class MonitoringObjectBase {
     this.medias = data.medias;
     this.siteId = data.site_id;
     this.idTableLocation = data.id_table_location;
+    this.cruved = data.cruved
   }
 
   idFieldName() {
@@ -198,10 +196,6 @@ export class MonitoringObjectBase {
       .configModuleObjectParam(this.moduleCode, this.objectType, fieldName);
   }
 
-  cruved(c = null) {
-    const cruved = this.configParam('cruved') || {};
-    return c ? (![undefined, null].includes(cruved[c]) ? cruved[c] : 1) : cruved;
-  }
 
   childrenTypes(configParam: string = null): Array<string> {
     let childrenTypes = this.configParam('children_types') || [];

--- a/frontend/app/class/monitoring-object.ts
+++ b/frontend/app/class/monitoring-object.ts
@@ -309,6 +309,7 @@ export class MonitoringObject extends MonitoringObjectBase {
           (fieldName) => child.resolvedProperties[fieldName]
         );
         row['id'] = child.id;
+        row['cruved'] = child.cruved
         return row;
       });
     }

--- a/frontend/app/components/modules/modules.component.css
+++ b/frontend/app/components/modules/modules.component.css
@@ -72,3 +72,7 @@ a {
   width: 100%;
   object-fit: cover;
 }
+
+.isDisableBtn {
+  opacity: 90%;
+}

--- a/frontend/app/components/modules/modules.component.html
+++ b/frontend/app/components/modules/modules.component.html
@@ -14,15 +14,12 @@
     <div class="col-md-4 col-sm-12 des-module">{{ description }}</div>
     <!-- <div class="w-100 d-none d-sm-block"></div> -->
     <div class="btn-module col-md-8 col-sm-12 text-center">
-      <div
-        matTooltip="Vous n'avez pas les accès nécessaires"
-        [matTooltipDisabled]="!isDisableAccessSite"
-      >
+      <div [matTooltip]="toolTipNotAllowed" [matTooltipDisabled]="canAccessSite">
         <button
           mat-flat-button
           color="primary"
-          [ngClass]="{ isDisableBtn: isDisableAccessSite }"
-          [disabled]="isDisableAccessSite"
+          [ngClass]="{ isDisableBtn: !canAccessSite }"
+          [disabled]="!canAccessSite"
           [routerLink]="'sites_group'"
           *ngIf="currentUser"
         >

--- a/frontend/app/components/modules/modules.component.html
+++ b/frontend/app/components/modules/modules.component.html
@@ -14,9 +14,21 @@
     <div class="col-md-4 col-sm-12 des-module">{{ description }}</div>
     <!-- <div class="w-100 d-none d-sm-block"></div> -->
     <div class="btn-module col-md-8 col-sm-12 text-center">
-      <button class="btn btn-success mr-2" [routerLink]="'sites_group'" *ngIf="currentUser">
-        Accès aux sites
-      </button>
+      <div
+        matTooltip="Vous n'avez pas les accès nécessaires"
+        [matTooltipDisabled]="!isDisableAccessSite"
+      >
+        <button
+          mat-flat-button
+          color="primary"
+          [ngClass]="{ isDisableBtn: isDisableAccessSite }"
+          [disabled]="isDisableAccessSite"
+          [routerLink]="'sites_group'"
+          *ngIf="currentUser"
+        >
+          Accès aux sites
+        </button>
+      </div>
       <div class="container py-5 border rounded m-2">
         <h3>Liste des protocoles</h3>
         <div class="row row-eq-height" style="overflow-x: auto">

--- a/frontend/app/components/modules/modules.component.ts
+++ b/frontend/app/components/modules/modules.component.ts
@@ -1,12 +1,15 @@
 import { Utils } from './../../utils/utils';
 import { Component, OnInit } from '@angular/core';
-import { mergeMap } from 'rxjs/operators';
+import { concatMap, map, mergeMap } from 'rxjs/operators';
 
 /** services */
 import { DataMonitoringObjectService } from '../../services/data-monitoring-object.service';
 import { ConfigService } from '../../services/config.service';
 import { get } from 'https';
 import { AuthService, User } from '@geonature/components/auth/auth.service';
+import { TPermission } from '../../types/permission';
+import { ObjectsPermissionMonitorings } from '../../enum/objectPermission';
+import { PermissionService } from '../../services/permission.service';
 
 @Component({
   selector: 'pnx-monitoring-modules',
@@ -15,6 +18,21 @@ import { AuthService, User } from '@geonature/components/auth/auth.service';
 })
 export class ModulesComponent implements OnInit {
   currentUser: User;
+  isDisableAccessSite: boolean = false;
+  currentPermission: TPermission = {
+    [ObjectsPermissionMonitorings.GNM_GRP_SITES]: {
+      canCreate: false,
+      canRead: false,
+      canUpdate: false,
+      canDelete: false,
+    },
+    [ObjectsPermissionMonitorings.GNM_SITES]: {
+      canCreate: false,
+      canRead: false,
+      canUpdate: false,
+      canDelete: false,
+    },
+  };
 
   description: string;
   titleModule: string;
@@ -31,7 +49,8 @@ export class ModulesComponent implements OnInit {
   constructor(
     private _auth: AuthService,
     private _dataMonitoringObjectService: DataMonitoringObjectService,
-    private _configService: ConfigService
+    private _configService: ConfigService,
+    private _permissionService: PermissionService
   ) {}
 
   ngOnInit() {
@@ -39,7 +58,19 @@ export class ModulesComponent implements OnInit {
     this._configService
       .init()
       .pipe(
-        mergeMap(
+        concatMap(() =>
+          this._dataMonitoringObjectService.getCruvedMonitoring().pipe(
+            map((listObjectCruved: Object) => {
+              this._permissionService.setPermissionMonitorings(listObjectCruved);
+            })
+          )
+        ),
+        concatMap(() =>
+          this._permissionService.currentPermissionObj.pipe(
+            map((permissionObject: TPermission) => (this.currentPermission = permissionObject))
+          )
+        ),
+        concatMap(
           this._dataMonitoringObjectService.getModules.bind(this._dataMonitoringObjectService)
         )
       )
@@ -55,6 +86,9 @@ export class ModulesComponent implements OnInit {
         this.bLoading = false;
         this.description = this._configService.descriptionModule();
         this.titleModule = this._configService.titleModule();
+
+        this.isDisableAccessSite =
+          this.currentPermission.GNM_SITES.canRead && this.currentPermission.GNM_GRP_SITES.canRead;
       });
 
     this.currentUser = this._auth.getCurrentUser();

--- a/frontend/app/components/modules/modules.component.ts
+++ b/frontend/app/components/modules/modules.component.ts
@@ -10,6 +10,7 @@ import { AuthService, User } from '@geonature/components/auth/auth.service';
 import { TPermission } from '../../types/permission';
 import { ObjectsPermissionMonitorings } from '../../enum/objectPermission';
 import { PermissionService } from '../../services/permission.service';
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 
 @Component({
   selector: 'pnx-monitoring-modules',
@@ -18,7 +19,7 @@ import { PermissionService } from '../../services/permission.service';
 })
 export class ModulesComponent implements OnInit {
   currentUser: User;
-  isDisableAccessSite: boolean = false;
+  canAccessSite: boolean = false;
   currentPermission: TPermission = {
     [ObjectsPermissionMonitorings.GNM_GRP_SITES]: {
       canCreate: false,
@@ -45,6 +46,8 @@ export class ModulesComponent implements OnInit {
   assetsDirectory: string;
 
   bLoading = false;
+
+  toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
 
   constructor(
     private _auth: AuthService,
@@ -87,8 +90,8 @@ export class ModulesComponent implements OnInit {
         this.description = this._configService.descriptionModule();
         this.titleModule = this._configService.titleModule();
 
-        this.isDisableAccessSite =
-          this.currentPermission.GNM_SITES.canRead && this.currentPermission.GNM_GRP_SITES.canRead;
+        this.canAccessSite =
+          this.currentPermission.GNM_SITES.canRead || this.currentPermission.GNM_GRP_SITES.canRead;
       });
 
     this.currentUser = this._auth.getCurrentUser();

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.css
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.css
@@ -64,3 +64,18 @@
 .hide-spinner {
   display: none;
 }
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}
+
+.isDisableBtn {
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.isDisableIcon {
+  opacity: 90%;
+  color: gray;
+}

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -51,9 +51,11 @@
               <!-- TODO Revoir pour les droits pour pouvoir créer un groupe de site avec anciennement:  *ngIf=obj.moduleCode && (currentUser['cruved_object'][child0.objectType] || currentUser['cruved']).C >= child0.cruved('C')" -->
               <button
                 mat-raised-button
+                [disabled]="!canCreateObj"
                 color="primary"
                 class="btn btn-success float-right"
-                (click)="navigateToAddObj()"
+                (click)="canCreateObj ? navigateToAddObj() : null"
+                [matTooltip]="canCreateObj ? null : toolTipNotAllowed"
               >
                 <i class="fa fa-plus" aria-hidden="true"></i> {{ dataTableArray[i].addObjLabel }}
               </button>
@@ -108,11 +110,18 @@
                   >
                     <ng-container *ngIf="!dataTableArray[i].addChildLabel.includes('observation')">
                       <a
+                        [ngClass]="{ isDisableBtn: !canCreateChild }"
                         class="nav-link link cell-link"
-                        (click)="navigateToAddChildren(null, row)"
-                        matTooltip=" {{ dataTableArray[i].addChildLabel }}"
+                        (click)="canCreateChild ? navigateToAddChildren(null, row) : null"
+                        [matTooltip]="
+                          canCreateChild ? dataTableArray[i].addChildLabel : toolTipNotAllowed
+                        "
                       >
-                        <i class="fa fa-plus" aria-hidden="true"></i>
+                        <i
+                          [ngClass]="{ isDisableIcon: !canCreateChild }"
+                          class="fa fa-plus"
+                          aria-hidden="true"
+                        ></i>
                       </a>
                     </ng-container>
                   </ng-template>
@@ -128,22 +137,34 @@
                   </ng-template>
                   <!--  -->
                   <a
+                    [ngClass]="{ isDisableBtn: !canUpdateObj }"
                     class="nav-link link cell-link"
-                    (click)="editSelectedItem(row)"
-                    matTooltip="{{ dataTableArray[i].editObjLabel }}"
+                    (click)="canUpdateObj ? editSelectedItem(row) : null"
+                    [matTooltip]="canUpdateObj ? dataTableArray[i].editObjLabel : toolTipNotAllowed"
                   >
-                    <i class="fa fa-edit" aria-hidden="true"></i>
+                    <i
+                      [ngClass]="{ isDisableIcon: !canUpdateObj }"
+                      class="fa fa-edit"
+                      aria-hidden="true"
+                    ></i>
                   </a>
 
                   <ng-container
                     *ngIf="dataTableArray[i].objectType == 'visit' ? true : row['nb_visits'] == 0"
                   >
                     <a
+                      [ngClass]="{ isDisableBtn: !canDeleteObj }"
                       class="nav-link link cell-link"
-                      (click)="alertMessage(row)"
-                      matTooltip="{{ dataTableArray[i].deleteObjLabel }}"
+                      (click)="canDeleteObj ? alertMessage(row) : null"
+                      [matTooltip]="
+                        canDeleteObj ? dataTableArray[i].deleteObjLabel : toolTipNotAllowed
+                      "
                     >
-                      <i class="fa fa-trash" aria-hidden="true"></i>
+                      <i
+                        [ngClass]="{ isDisableIcon: !canDeleteObj }"
+                        class="fa fa-trash"
+                        aria-hidden="true"
+                      ></i>
                     </a>
                   </ng-container>
                 </ng-template>

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -137,13 +137,15 @@
                   </ng-template>
                   <!--  -->
                   <a
-                    [ngClass]="{ isDisableBtn: !canUpdateObj }"
+                    [ngClass]="{ isDisableBtn: !row.permissions['U'] }"
                     class="nav-link link cell-link"
-                    (click)="canUpdateObj ? editSelectedItem(row) : null"
-                    [matTooltip]="canUpdateObj ? dataTableArray[i].editObjLabel : toolTipNotAllowed"
+                    (click)="row.permissions['U'] ? editSelectedItem(row) : null"
+                    [matTooltip]="
+                      row.permissions['U'] ? dataTableArray[i].editObjLabel : toolTipNotAllowed
+                    "
                   >
                     <i
-                      [ngClass]="{ isDisableIcon: !canUpdateObj }"
+                      [ngClass]="{ isDisableIcon: !row.permissions['U'] }"
                       class="fa fa-edit"
                       aria-hidden="true"
                     ></i>
@@ -153,15 +155,15 @@
                     *ngIf="dataTableArray[i].objectType == 'visit' ? true : row['nb_visits'] == 0"
                   >
                     <a
-                      [ngClass]="{ isDisableBtn: !canDeleteObj }"
+                      [ngClass]="{ isDisableBtn: !row.permissions['D'] }"
                       class="nav-link link cell-link"
-                      (click)="canDeleteObj ? alertMessage(row) : null"
+                      (click)="row.permissions['D'] ? alertMessage(row) : null"
                       [matTooltip]="
-                        canDeleteObj ? dataTableArray[i].deleteObjLabel : toolTipNotAllowed
+                        row.permissions['D'] ? dataTableArray[i].deleteObjLabel : toolTipNotAllowed
                       "
                     >
                       <i
-                        [ngClass]="{ isDisableIcon: !canDeleteObj }"
+                        [ngClass]="{ isDisableIcon: !row.permissions['D'] }"
                         class="fa fa-trash"
                         aria-hidden="true"
                       ></i>

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -137,15 +137,15 @@
                   </ng-template>
                   <!--  -->
                   <a
-                    [ngClass]="{ isDisableBtn: !row.permissions['U'] }"
+                    [ngClass]="{ isDisableBtn: !row.cruved['U'] }"
                     class="nav-link link cell-link"
-                    (click)="row.permissions['U'] ? editSelectedItem(row) : null"
+                    (click)="row.cruved['U'] ? editSelectedItem(row) : null"
                     [matTooltip]="
-                      row.permissions['U'] ? dataTableArray[i].editObjLabel : toolTipNotAllowed
+                      row.cruved['U'] ? dataTableArray[i].editObjLabel : toolTipNotAllowed
                     "
                   >
                     <i
-                      [ngClass]="{ isDisableIcon: !row.permissions['U'] }"
+                      [ngClass]="{ isDisableIcon: !row.cruved['U'] }"
                       class="fa fa-edit"
                       aria-hidden="true"
                     ></i>
@@ -155,15 +155,15 @@
                     *ngIf="dataTableArray[i].objectType == 'visit' ? true : row['nb_visits'] == 0"
                   >
                     <a
-                      [ngClass]="{ isDisableBtn: !row.permissions['D'] }"
+                      [ngClass]="{ isDisableBtn: !row.cruved['D'] }"
                       class="nav-link link cell-link"
-                      (click)="row.permissions['D'] ? alertMessage(row) : null"
+                      (click)="row.cruved['D'] ? alertMessage(row) : null"
                       [matTooltip]="
-                        row.permissions['D'] ? dataTableArray[i].deleteObjLabel : toolTipNotAllowed
+                        row.cruved['D'] ? dataTableArray[i].deleteObjLabel : toolTipNotAllowed
                       "
                     >
                       <i
-                        [ngClass]="{ isDisableIcon: !row.permissions['D'] }"
+                        [ngClass]="{ isDisableIcon: !row.cruved['D'] }"
                         class="fa fa-trash"
                         aria-hidden="true"
                       ></i>

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -53,6 +53,7 @@
                 mat-raised-button
                 [disabled]="!canCreateObj"
                 color="primary"
+                [ngClass]="{ isDisableBtn: !canCreateObj }" 
                 class="btn btn-success float-right"
                 (click)="canCreateObj ? navigateToAddObj() : null"
                 [matTooltip]="canCreateObj ? null : toolTipNotAllowed"

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -83,8 +83,6 @@ export class MonitoringDatatableGComponent implements OnInit {
   rowSelected;
 
   canCreateObj: boolean;
-  canUpdateObj: boolean;
-  canDeleteObj: boolean;
   canCreateChild: boolean;
 
   toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
@@ -145,6 +143,7 @@ export class MonitoringDatatableGComponent implements OnInit {
     this.page = this.dataTableObj[this.activetabType].page;
     this.objectsStatusChange.emit(this.reInitStatut());
     this.tabChanged.emit(this.activetabType);
+    this.initPermissionAction()
   }
 
   reInitStatut() {
@@ -254,35 +253,28 @@ export class MonitoringDatatableGComponent implements OnInit {
       case 'sites_group':
         objectType = ObjectsPermissionMonitorings.GNM_GRP_SITES;
         objectTypeChild = ObjectsPermissionMonitorings.GNM_SITES;
+        this.canCreateChild = this.permission[objectTypeChild].canCreate ? true : false;
         break;
       case 'site':
         objectType = ObjectsPermissionMonitorings.GNM_SITES;
         objectTypeChild = 'visit';
+        this.canCreateChild = true;
         break;
       case 'visit':
         objectType = 'visit';
         objectTypeChild = 'undefined';
-        this.canDeleteObj = true;
-        this.canUpdateObj = true;
+        this.canCreateObj = true;
         this.canCreateChild = true;
         break;
       default:
         objectType = 'undefined';
         objectTypeChild = 'undefined';
         this.canCreateObj = false;
-        this.canDeleteObj = false;
-        this.canUpdateObj = false;
         this.canCreateChild = false;
     }
 
-    if (objectType != 'undefined') {
+    if (!['undefined','visit'].includes(objectType)) {
       this.canCreateObj = this.permission[objectType].canCreate ? true : false;
-      this.canUpdateObj = this.permission[objectType].canUpdate ? true : false;
-      this.canDeleteObj = this.permission[objectType].canDelete ? true : false;
-    }
-
-    if (objectTypeChild != 'visit') {
-      this.canCreateChild = this.permission[objectTypeChild].canCreate ? true : false;
     }
   }
 

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -13,6 +13,7 @@ import { DatatableComponent } from '@swimlane/ngx-datatable';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 import { IColumn } from '../../interfaces/column';
 import { IobjObs, ObjDataType } from '../../interfaces/objObs';
 import { IPage } from '../../interfaces/page';
@@ -21,6 +22,8 @@ import { ObjectService } from '../../services/object.service';
 import { Utils } from '../../utils/utils';
 import { SelectObject } from '../../interfaces/object';
 import { CommonService } from '@geonature_common/service/common.service';
+import { TPermission } from '../../types/permission';
+import { ObjectsPermissionMonitorings } from '../../enum/objectPermission';
 
 interface ItemObjectTable {
   id: number | null;
@@ -49,6 +52,7 @@ export class MonitoringDatatableGComponent implements OnInit {
   @Output() saveOptionChildren = new EventEmitter<SelectObject>();
   @Output() bEditChanged = new EventEmitter<boolean>();
   @Input() currentUser;
+  @Input() permission: TPermission;
 
   @Output() onSort = new EventEmitter<any>();
   @Output() onFilter = new EventEmitter<any>();
@@ -77,6 +81,13 @@ export class MonitoringDatatableGComponent implements OnInit {
   filters = {};
 
   rowSelected;
+
+  canCreateObj: boolean;
+  canUpdateObj: boolean;
+  canDeleteObj: boolean;
+  canCreateChild: boolean;
+
+  toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
 
   @Input() activetabIndex: number = 0;
   activetabType: string;
@@ -236,6 +247,45 @@ export class MonitoringDatatableGComponent implements OnInit {
     this.table.offset = Math.floor(index_row_selected / this.table._limit);
   }
 
+  initPermissionAction() {
+    let objectType: ObjectsPermissionMonitorings | string;
+    let objectTypeChild: ObjectsPermissionMonitorings | string;
+    switch (this.activetabType) {
+      case 'sites_group':
+        objectType = ObjectsPermissionMonitorings.GNM_GRP_SITES;
+        objectTypeChild = ObjectsPermissionMonitorings.GNM_SITES;
+        break;
+      case 'site':
+        objectType = ObjectsPermissionMonitorings.GNM_SITES;
+        objectTypeChild = 'visit';
+        break;
+      case 'visit':
+        objectType = 'visit';
+        objectTypeChild = 'undefined';
+        this.canDeleteObj = true;
+        this.canUpdateObj = true;
+        this.canCreateChild = true;
+        break;
+      default:
+        objectType = 'undefined';
+        objectTypeChild = 'undefined';
+        this.canCreateObj = false;
+        this.canDeleteObj = false;
+        this.canUpdateObj = false;
+        this.canCreateChild = false;
+    }
+
+    if (objectType != 'undefined') {
+      this.canCreateObj = this.permission[objectType].canCreate ? true : false;
+      this.canUpdateObj = this.permission[objectType].canUpdate ? true : false;
+      this.canDeleteObj = this.permission[objectType].canDelete ? true : false;
+    }
+
+    if (objectTypeChild != 'visit') {
+      this.canCreateChild = this.permission[objectTypeChild].canCreate ? true : false;
+    }
+  }
+
   ngOnDestroy() {
     this.filterSubject.unsubscribe();
     if (this.subscription) {
@@ -269,12 +319,14 @@ export class MonitoringDatatableGComponent implements OnInit {
         : null;
       this.rows = this.dataTableObj[this.activetabType].rows;
       this.page = this.dataTableObj[this.activetabType].page;
+      this.initPermissionAction();
     }
 
     if (changes['rows'] && this.rows && this.rows.length > 0) {
       this.activetabType = this.dataTableArray[this.activetabIndex].objectType;
       this.rows = this.dataTableObj[this.activetabType].rows;
       this.page = this.dataTableObj[this.activetabType].page;
+      this.initPermissionAction();
     }
 
     for (const propName of Object.keys(changes)) {

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.css
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.css
@@ -46,3 +46,19 @@
 .custom-dt {
   box-shadow: none !important;
 }
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}
+
+.isDisableBtn {
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.isDisableIcon {
+  opacity: 90%;
+  color: gray;
+}
+

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
@@ -55,27 +55,30 @@
         </a>
         <a
           *ngIf="child0.child0()"
+          [ngClass]="{ isDisableBtn: !canCreateChild }"
           class="nav-link link cell-link"
-          (click)="child0.navigateToAddChildren(null, row.id)"
-          matTooltip="Ajouter {{ child0.child0().labelArtUndef(true) }}"
+          (click)="canCreateChild ? child0.navigateToAddChildren(null, row.id): null"
+          [matTooltip]="canCreateChild ? ('Ajouter' + child0.child0().labelArtUndef(true)) : toolTipNotAllowed"
         >
-          <i class="fa fa-plus" aria-hidden="true"></i>
+          <i [ngClass]="{ isDisableIcon: !canCreateChild }" class="fa fa-plus" aria-hidden="true"></i>
         </a>
         <!-- TODO: rajouter les permission currentUser  *ngIf="currentUser?.moduleCruved[child0.objectType].U >= child0.config.cruved('U')" -->
         <a
+          [ngClass]="{ isDisableBtn: !row.cruved['U'] }"
           class="nav-link link cell-link"
-          (click)="child0.navigateToDetail(row.id, true)"
-          matTooltip="Eiter  {{ child0.template.label_art_def }}"
+          (click)="row.cruved['U'] ? child0.navigateToDetail(row.id, true) : null"
+          [matTooltip]="row.cruved['U'] ? ('Editer' +child0.template.label_art_def) : toolTipNotAllowed"
         >
-          <i class="fa fa-edit" aria-hidden="true"></i>
+          <i [ngClass]="{ isDisableIcon: !row.cruved['U'] }" class="fa fa-edit" aria-hidden="true"></i>
         </a>
         <ng-container *ngIf="child0.objectType == 'visit' ? true : row['nb_visits'] == 0">
           <a
+            [ngClass]="{ isDisableBtn: !row.cruved['D'] }"
             class="nav-link link cell-link"
-            (click)="alertMessage(row)"
-            matTooltip="Supprimer {{ child0.template.label_art_def }}"
+            (click)="row.cruved['D'] ? alertMessage(row) : null"
+            [matTooltip]="row.cruved['D'] ? ('Supprimer' +child0.template.label_art_def) : toolTipNotAllowed"
           >
-            <i class="fa fa-trash" aria-hidden="true"></i>
+            <i [ngClass]="{ isDisableIcon: !row.cruved['D'] }" class="fa fa-trash" aria-hidden="true"></i>
           </a>
         </ng-container>
       </ng-template>

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
@@ -15,6 +15,7 @@ import { Subject } from 'rxjs';
 import { catchError, map, tap, take, debounceTime } from 'rxjs/operators';
 import { CommonService } from '@geonature_common/service/common.service';
 import { ObjectService } from '../../services/object.service';
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 
 @Component({
   selector: 'pnx-monitoring-datatable',
@@ -53,6 +54,8 @@ export class MonitoringDatatableComponent implements OnInit {
   rowSelected;
   bDeleteModal: boolean = false;
   bDeleteSpinner: boolean = false;
+  toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
+  canCreateChild:boolean =false;
 
   constructor(
     private _monitoring: MonitoringObjectService,
@@ -62,6 +65,13 @@ export class MonitoringDatatableComponent implements OnInit {
 
   ngOnInit() {
     this.initDatatable();
+    this.initPermission();
+  }
+
+  initPermission(){
+    // TODO: Attention ici l'ajout avec l'icon ne se fait que sur un enfant (si plusieurs enfants au même niveau , le premier sera pris pour le moment)
+  const childrenType = this.child0.config.children_types[0]
+  this.canCreateChild = this.currentUser?.moduleCruved[childrenType]["C"]
   }
 
   initDatatable() {

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.css
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.css
@@ -49,3 +49,8 @@ form.ng-invalid {
   overflow: hidden;
   height: fit-content;
 }
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.html
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.html
@@ -118,7 +118,7 @@
             mat-raised-button
             color="primary"
             class="float-right"
-            (click)="bSaveSpinner = true; onSubmit()"
+            (click)="canUpdate ? onSubmit() : notAllowedMessage()"
             [disabled]="isExtraForm ? (objForm.dynamic.status == 'INVALID' || extraFormCtrl?.frmCtrl.status == 'INVALID' || objForm.static.status == 'INVALID') : objForm.static.status == 'INVALID'  "
           >
             <span
@@ -139,10 +139,12 @@
             Annuler
           </button>
           <button
-            mat-raised-button
-            color="warn"
-            class="float-left"
-            (click)="bDeleteModal = true"
+          mat-raised-button
+          [matTooltip]="canDelete ? null : toolTipNotAllowed"
+          [disabled]="!canDelete"
+          color="warn"
+          class="float-left"
+          (click)="canDelete ? bDeleteModal = true : null"
             *ngIf="obj.id"
           >
             Supprimer

--- a/frontend/app/components/monitoring-form/monitoring-form.component.css
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.css
@@ -49,3 +49,8 @@ form.ng-invalid {
   overflow: hidden;
   height: fit-content;
 }
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}

--- a/frontend/app/components/monitoring-form/monitoring-form.component.html
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.html
@@ -90,7 +90,7 @@
           color="primary"
           *ngIf="!bChainInput && !obj.id && obj.uniqueChildrenName()"
           class="btn btn-success float-right"
-          (click)="bSaveAndAddChildrenSpinner = bAddChildren = true; onSubmit()"
+          (click)="canUpdate ? onSubmit(true) : notAllowedMessage()"
           [disabled]="!objForm.valid"
         >
           <span
@@ -107,7 +107,7 @@
           mat-raised-button
           color="primary"
           class="float-right"
-          (click)="bSaveSpinner = true; onSubmit()"
+          (click)="canUpdate ? onSubmit() : notAllowedMessage()"
           [disabled]="!objForm.valid || !objFormDynamic.valid"
         >
           <span

--- a/frontend/app/components/monitoring-form/monitoring-form.component.html
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.html
@@ -126,13 +126,13 @@
         </button>
         <button
           mat-raised-button
+          [matTooltip]="canDelete ? null : toolTipNotAllowed"
+          [disabled]="!canDelete"
           color="warn"
           class="float-left"
-          (click)="bDeleteModal = true"
+          (click)="canDelete ? bDeleteModal = true : null"
           *ngIf="
-            obj.id &&
-            currentUser.moduleCruved[obj.objectType].D >= obj.cruved('D') &&
-            !obj.objectType.includes('site', 'sites_group')
+            obj.id
           "
         >
           Supprimer

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -21,6 +21,7 @@ import {
 import { EMPTY, from, iif, of } from 'rxjs';
 import { FormService } from '../../services/form.service';
 import { Router } from '@angular/router';
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 
 @Component({
   selector: 'pnx-monitoring-form',
@@ -67,6 +68,9 @@ export class MonitoringFormComponent implements OnInit {
   public chainShow = [];
 
   public queryParams = {};
+  
+  canDelete:boolean;
+  toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
 
   constructor(
     private _formBuilder: FormBuilder,
@@ -81,6 +85,7 @@ export class MonitoringFormComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    this.initPermission()
     this._configService
       .init(this.obj.moduleCode)
       .pipe(
@@ -651,5 +656,9 @@ export class MonitoringFormComponent implements OnInit {
       .sort((a, b) => {
         return a.attribut_name === 'types_site' ? -1 : b.attribut_name === 'types_site' ? +1 : 0;
       });
+  }
+
+  initPermission(){
+    this.canDelete = this.obj.objectType == 'module' ? this.currentUser?.moduleCruved[this.obj.objectType]['D'] > 0 : (this.obj.cruved['D'] && !['site', 'sites_group'].includes(this.obj.objectType))
   }
 }

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -70,6 +70,7 @@ export class MonitoringFormComponent implements OnInit {
   public queryParams = {};
   
   canDelete:boolean;
+  canUpdate:boolean;
   toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
 
   constructor(
@@ -329,7 +330,8 @@ export class MonitoringFormComponent implements OnInit {
   }
 
   /** TODO améliorer site etc.. */
-  onSubmit() {
+  onSubmit(isAddChildrend=false) {
+    isAddChildrend ? this.bSaveAndAddChildrenSpinner = this.bAddChildren = true : this.bSaveSpinner = true;  
     if (this.obj.objectType == 'site') {
       this.dataComplement = { ...this.typesSiteConfig, types_site: this.idsTypesSite };
     }
@@ -660,5 +662,13 @@ export class MonitoringFormComponent implements OnInit {
 
   initPermission(){
     this.canDelete = this.obj.objectType == 'module' ? this.currentUser?.moduleCruved[this.obj.objectType]['D'] > 0 : (this.obj.cruved['D'] && !['site', 'sites_group'].includes(this.obj.objectType))
+    this.canUpdate = this.obj.objectType == 'module' ? this.currentUser?.moduleCruved[this.obj.objectType]['U'] > 0 : this.obj.cruved['U']
+  }
+
+  notAllowedMessage(){
+    this._commonService.translateToaster(
+      'warning',
+      "Vous n'avez pas les permissions nécessaires pour éditer l'objet"
+    );
   }
 }

--- a/frontend/app/components/monitoring-lists/monitoring-lists.component.css
+++ b/frontend/app/components/monitoring-lists/monitoring-lists.component.css
@@ -9,3 +9,13 @@
 .btn-float-right {
   margin: 5px 0;
 }
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}
+
+.isDisableBtn {
+  cursor: not-allowed;
+  text-decoration: none;
+}

--- a/frontend/app/components/monitoring-lists/monitoring-lists.component.html
+++ b/frontend/app/components/monitoring-lists/monitoring-lists.component.html
@@ -15,20 +15,21 @@
               (click)="child0.config['display_filter'] = !child0.config['display_filter']"
               matTooltip="{{ child0.config['display_filter'] ? 'Cacher' : 'Afficher' }} les filtres"
               *ngIf="
-                obj.moduleCode &&
-                currentUser.moduleCruved[child0.objectType].R >= child0.cruved('R')
+                obj.moduleCode
               "
             >
               <mat-icon>filter_alt</mat-icon>
             </button>
             <button
               mat-raised-button
+              [disabled]="!canCreateChild[child0.objectType]"
               color="primary"
+              [ngClass]="{ isDisableBtn: !canCreateChild[child0.objectType] }" 
               class="btn btn-success float-right"
-              (click)="obj.navigateToAddChildren(child0.objectType)"
+              (click)="canCreateChild[child0.objectType] ? obj.navigateToAddChildren(child0.objectType) : null"
+              [matTooltip]="canCreateChild[child0.objectType] ? null : toolTipNotAllowed"
               *ngIf="
-                obj.moduleCode &&
-                currentUser.moduleCruved[child0.objectType].C >= child0.cruved('C')
+                obj.moduleCode
               "
             >
               <i class="fa fa-plus" aria-hidden="true"></i> Ajouter

--- a/frontend/app/components/monitoring-lists/monitoring-lists.component.ts
+++ b/frontend/app/components/monitoring-lists/monitoring-lists.component.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '../../services/config.service';
 import { MonitoringObject } from '../../class/monitoring-object';
 
 import { Utils } from '../../utils/utils';
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 
 @Component({
   selector: 'pnx-monitoring-lists',
@@ -37,6 +38,8 @@ export class MonitoringListComponent implements OnInit {
   @Input() objectsStatus: Object;
   @Output() objectsStatusChange: EventEmitter<Object> = new EventEmitter<Object>();
 
+  canCreateChild: {[key:string]:boolean} = {};
+  toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
   constructor(private _configService: ConfigService) {}
 
   ngOnInit() {
@@ -44,6 +47,7 @@ export class MonitoringListComponent implements OnInit {
       this.initDataTable();
     });
   }
+
 
   initDataTable() {
     for (const key of Object.keys(this.obj.children)) {
@@ -62,7 +66,15 @@ export class MonitoringListComponent implements OnInit {
     // datatable
     this.childrenDataTable = this.obj.childrenColumnsAndRows('display_list');
 
+    this.initPermission()
     // this.medias = this.obj.children['media'] && this.obj.children['media'].map(e => e.properties);
+  }
+
+  initPermission(){
+    for (const child of this.children0Array){
+      const childType = child['objectType']
+      this.canCreateChild[childType] = this.currentUser?.moduleCruved[childType].C>0
+    }
   }
 
   onSelectedChildren(typeObject, event) {

--- a/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.css
+++ b/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.css
@@ -30,3 +30,8 @@ td {
 ::ng-deep .cdk-overlay-container {
   z-index: 99999 !important;
 }
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}

--- a/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.html
+++ b/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.html
@@ -131,10 +131,12 @@
 
       <button
         mat-stroked-button
+        [disabled]="!canUpdateObj"
         color="primary"
         class="mr-2"
-        (click)="onEditClick()"
+        (click)="canUpdateObj ? onEditClick() : null"
         *ngIf="!bEdit"
+        [matTooltip]="canUpdateObj ? null : toolTipNotAllowed"
       >
         {{ objectType.editObjLabel }}
       </button>

--- a/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.ts
+++ b/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.ts
@@ -78,31 +78,13 @@ export class MonitoringPropertiesGComponent implements OnInit {
     this.bEditChange.emit(true);
   }
 
-  initPermission() {
-    let objectType: ObjectsPermissionMonitorings | string;
-    switch (this.newParentType.objectType) {
-      case 'sites_group':
-        objectType = ObjectsPermissionMonitorings.GNM_GRP_SITES;
-        break;
-      case 'site':
-        objectType = ObjectsPermissionMonitorings.GNM_SITES;
-        break;
-      case 'visit':
-        objectType = 'visit';
-        break;
-      default:
-        objectType = 'undefined';
-        this.canUpdateObj = false;
-        break
-    }
-    if (!['undefined','visit'].includes(objectType))
-    this.canUpdateObj = this.permission[objectType].canUpdate ? true : false;
-  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.newParentType && this.newParentType.template.fieldNames.length != 0) {
-      this.initPermission();
       this.initProperties();
+      if(this.selectedObj){
+        this.canUpdateObj = this.selectedObj['cruved']['U'] 
+      }
       if (
         this.newParentType.template_specific &&
         this.newParentType.template_specific.fieldNames &&

--- a/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.ts
+++ b/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.ts
@@ -2,11 +2,14 @@ import { Component, EventEmitter, Input, OnInit, Output, SimpleChanges } from '@
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 import { ISitesGroup } from '../../interfaces/geom';
 import { IobjObs, ObjDataType } from '../../interfaces/objObs';
 import { FormService } from '../../services/form.service';
 import { ObjectService } from '../../services/object.service';
 import { JsonData } from '../../types/jsondata';
+import { TPermission } from '../../types/permission';
+import { ObjectsPermissionMonitorings } from '../../enum/objectPermission';
 
 @Component({
   selector: 'pnx-monitoring-properties-g',
@@ -35,12 +38,20 @@ export class MonitoringPropertiesGComponent implements OnInit {
   specificFieldDefinitions: JsonData = {};
   specificFieldsNames: string[];
 
+  @Input() permission: TPermission;
+
+  canUpdateObj: boolean;
+
+  toolTipNotAllowed: string;
+
   constructor(
     private _formService: FormService,
     private _objService: ObjectService
   ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.toolTipNotAllowed = TOOLTIPMESSAGEALERT;
+  }
 
   initProperties() {
     this.objectType = this.newParentType;
@@ -67,8 +78,30 @@ export class MonitoringPropertiesGComponent implements OnInit {
     this.bEditChange.emit(true);
   }
 
+  initPermission() {
+    let objectType: ObjectsPermissionMonitorings | string;
+    switch (this.newParentType) {
+      case 'sites_group':
+        objectType = ObjectsPermissionMonitorings.GNM_GRP_SITES;
+        break;
+      case 'site':
+        objectType = ObjectsPermissionMonitorings.GNM_SITES;
+        break;
+      case 'visit':
+        objectType = 'visit';
+        break;
+      default:
+        objectType = 'undefined';
+        this.canUpdateObj = false;
+
+        if (objectType != 'undefined')
+          this.canUpdateObj = this.permission[objectType].canUpdate ? true : false;
+    }
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (this.newParentType && this.newParentType.template.fieldNames.length != 0) {
+      this.initPermission();
       this.initProperties();
       if (
         this.newParentType.template_specific &&

--- a/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.ts
+++ b/frontend/app/components/monitoring-properties-g/monitoring-properties-g.component.ts
@@ -80,7 +80,7 @@ export class MonitoringPropertiesGComponent implements OnInit {
 
   initPermission() {
     let objectType: ObjectsPermissionMonitorings | string;
-    switch (this.newParentType) {
+    switch (this.newParentType.objectType) {
       case 'sites_group':
         objectType = ObjectsPermissionMonitorings.GNM_GRP_SITES;
         break;
@@ -93,10 +93,10 @@ export class MonitoringPropertiesGComponent implements OnInit {
       default:
         objectType = 'undefined';
         this.canUpdateObj = false;
-
-        if (objectType != 'undefined')
-          this.canUpdateObj = this.permission[objectType].canUpdate ? true : false;
+        break
     }
+    if (!['undefined','visit'].includes(objectType))
+    this.canUpdateObj = this.permission[objectType].canUpdate ? true : false;
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/frontend/app/components/monitoring-properties/monitoring-properties.component.css
+++ b/frontend/app/components/monitoring-properties/monitoring-properties.component.css
@@ -30,3 +30,9 @@ td {
 ::ng-deep .cdk-overlay-container {
   z-index: 99999 !important;
 }
+
+
+button:disabled {
+  cursor: not-allowed;
+  pointer-events: all !important;
+}

--- a/frontend/app/components/monitoring-properties/monitoring-properties.component.html
+++ b/frontend/app/components/monitoring-properties/monitoring-properties.component.html
@@ -99,8 +99,10 @@
       mat-stroked-button
       color="primary"
       class="mr-2"
-      (click)="onEditClick()"
-      *ngIf="!bEdit && currentUser?.moduleCruved[obj.objectType].U >= obj.cruved('U')"
+      (click)="initPermission() ? onEditClick() : null"
+      *ngIf="!bEdit"
+      [matTooltip]="initPermission() ? null : toolTipNotAllowed"
+      [disabled]="!initPermission()"
     >
       Éditer {{ obj.template['label_art_def'] || '' }}
     </button>

--- a/frontend/app/components/monitoring-properties/monitoring-properties.component.ts
+++ b/frontend/app/components/monitoring-properties/monitoring-properties.component.ts
@@ -8,6 +8,7 @@ import html2canvas from 'html2canvas';
 import { MapService } from '@geonature_common/map/map.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { FormGroup, FormControl, FormBuilder, Validators } from '@angular/forms';
+import { TOOLTIPMESSAGEALERT } from '../../constants/guard';
 
 @Component({
   selector: 'pnx-monitoring-properties',
@@ -28,6 +29,10 @@ export class MonitoringPropertiesComponent implements OnInit {
   public modalReference;
   selectedDataSet: Array<number> = [];
 
+  canUpdateObj: boolean;
+
+  toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
+
   constructor(
     private _configService: ConfigService,
     public ms: MediaService,
@@ -39,6 +44,11 @@ export class MonitoringPropertiesComponent implements OnInit {
 
   ngOnInit() {
     this.backendUrl = this._configService.backendUrl();
+  }
+
+  initPermission() {
+    this.canUpdateObj =  this.obj.objectType == 'module' ? this.currentUser?.moduleCruved[this.obj.objectType]['U'] > 0 : this.obj.cruved['U'] 
+    return this.canUpdateObj
   }
 
   onEditClick() {

--- a/frontend/app/components/monitoring-sites/monitoring-sites.component.html
+++ b/frontend/app/components/monitoring-sites/monitoring-sites.component.html
@@ -10,6 +10,7 @@
   [selectedObj]="sitesGroup"
   [newParentType]="objParent"
   [selectedObjRaw]="sitesGroup"
+  [permission]="currentPermission"
 >
 </pnx-monitoring-properties-g>
 <pnx-monitoring-form-g
@@ -38,4 +39,5 @@
   (onDeleteEvent)="onDelete($event)"
   (saveOptionChildren)="onSaveAddChildren($event)"
   [bDeleteModalEmitter]="bDeleteModalEmitter"
+  [permission]="currentPermission"
 ></pnx-monitoring-datatable-g>

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.html
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.html
@@ -20,5 +20,6 @@
     (saveOptionChildren)="onSaveAddChildren($event)"
     [bDeleteModalEmitter]="bDeleteModalEmitter"
     [currentUser]="currentUser"
+    [permission]="currentPermission"
   ></pnx-monitoring-datatable-g>
 </div>

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.html
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.html
@@ -19,7 +19,7 @@
     (addFromTable)="onAddChildren($event)"
     (saveOptionChildren)="onSaveAddChildren($event)"
     [bDeleteModalEmitter]="bDeleteModalEmitter"
-    [currentUser]="currentUser"
     [permission]="currentPermission"
+    [currentUser]="currentUser"
   ></pnx-monitoring-datatable-g>
 </div>

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -20,6 +20,7 @@ import { ReplaySubject } from 'rxjs';
 import { AuthService, User } from '@geonature/components/auth/auth.service';
 import { TPermission } from '../../types/permission';
 
+
 const LIMIT = 10;
 
 @Component({

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -18,6 +18,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Module } from '../../interfaces/module';
 import { ReplaySubject } from 'rxjs';
 import { AuthService, User } from '@geonature/components/auth/auth.service';
+import { TPermission } from '../../types/permission';
 
 const LIMIT = 10;
 
@@ -61,6 +62,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
   bDeleteModalEmitter = new EventEmitter<boolean>();
 
   currentUser: User;
+  currentPermission: TPermission;
 
   constructor(
     private _auth: AuthService,
@@ -93,6 +95,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
     this._Activatedroute.data.subscribe(({ data }) => {
 
       this.currentUser = this._auth.getCurrentUser();
+      this.currentPermission = data.permission;
       this.page = {
         count: data.sitesGroups.data.count,
         limit: data.sitesGroups.data.limit,
@@ -106,12 +109,14 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       if (data.route == 'sites') {
         this.activetabIndex = 1;
         this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSites.value;
-        this.getGeometriesSite();
+        this.currentPermission.GNM_SITES.canRead ? this.getGeometriesSite() : null;
       } else {
         this.activetabIndex = 0;
-        this.geojsonService.getSitesGroupsGeometries(this.onEachFeatureSiteGroups());
+        this.currentPermission.GNM_GRP_SITES.canRead
+          ? this.geojsonService.getSitesGroupsGeometries(this.onEachFeatureSiteGroups())
+          : null;
       }
-      const { route, ...dataToTable } = data;
+      const { route, permission, ...dataToTable } = data;
 
       this.setDataTableObj(dataToTable);
       this.updateBreadCrumb();
@@ -270,7 +275,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSites.value;
       this.updateBreadCrumb();
       this.geojsonService.removeFeatureGroup(this.geojsonService.sitesGroupFeatureGroup);
-      this.getGeometriesSite();
+      this.currentPermission.GNM_SITES.canRead ? this.getGeometriesSite() : null;
     } else {
       this.activetabIndex = 0;
       this.currentRoute = 'sites_group';
@@ -278,7 +283,9 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSiteGroups.value;
       this.updateBreadCrumb();
       this.geojsonService.removeFeatureGroup(this.geojsonService.sitesFeatureGroup);
-      this.geojsonService.getSitesGroupsGeometries(this.onEachFeatureSiteGroups());
+      this.currentPermission.GNM_GRP_SITES.canRead
+        ? this.geojsonService.getSitesGroupsGeometries(this.onEachFeatureSiteGroups())
+        : null;
     }
   }
 

--- a/frontend/app/components/monitoring-visits/monitoring-visits.component.html
+++ b/frontend/app/components/monitoring-visits/monitoring-visits.component.html
@@ -36,6 +36,7 @@
   [newParentType]="objParent"
   [selectedObj]="objResolvedProperties"
   [selectedObjRaw]="objSelected"
+  [permission]="currentPermission"
 ></pnx-monitoring-properties-g>
 <pnx-monitoring-datatable-g
   *ngIf="!bEdit"
@@ -52,6 +53,7 @@
   (onEditEvent)="editChild($event)"
   (onDeleteEvent)="onDelete($event)"
   [bDeleteModalEmitter]="bDeleteModalEmitter"
+  [permission]="currentPermission"
 >
   <option-list-btn
     add-button

--- a/frontend/app/constants/guard.ts
+++ b/frontend/app/constants/guard.ts
@@ -1,1 +1,1 @@
-export const TOOLTIPMESSAGEALERT: string = "Vous n'avez pas les droits nécessaires";
+export const TOOLTIPMESSAGEALERT: string = "Vous n'avez pas les permissions nécessaires";

--- a/frontend/app/constants/guard.ts
+++ b/frontend/app/constants/guard.ts
@@ -1,0 +1,1 @@
+export const TOOLTIPMESSAGEALERT: string = "Vous n'avez pas les droits nécessaires";

--- a/frontend/app/enum/objectPermission.ts
+++ b/frontend/app/enum/objectPermission.ts
@@ -1,0 +1,4 @@
+export enum ObjectsPermissionMonitorings {
+  GNM_GRP_SITES = 'GNM_GRP_SITES',
+  GNM_SITES = 'GNM_SITES',
+}

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -99,6 +99,12 @@ const routes: Routes = [
         resolve: {
           data: SitesGroupsReslver,
         },
+        // TODO: voir si on bloque l'accès en lecture
+        // canActivate: [PermissionGuard],
+        // data: {
+        //   expectedPermission: 'Read',
+        //   objectPermission: [ObjectsPermissionMonitorings.GNM_GRP_SITES],
+        // },
       },
       {
         path: 'create',
@@ -121,6 +127,11 @@ const routes: Routes = [
             component: MonitoringSitesCreateComponent,
             resolve: {
               data: CreateSiteResolver,
+            },
+            canActivate: [PermissionGuard],
+            data: {
+              expectedPermission: 'Create',
+              objectPermission: [ObjectsPermissionMonitorings.GNM_GRP_SITES],
             },
           },
           {

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -43,6 +43,8 @@ import { MonitoringMapListComponent } from './components/monitoring-map-list/mon
 import { MonitoringFormComponentG } from './components/monitoring-form-g/monitoring-form.component-g';
 import { FormService } from './services/form.service';
 import { ObjectService } from './services/object.service';
+import { PermissionService } from './services/permission.service';
+import { PermissionGuard } from './services/permission.guard';
 import {
   SitesGroupService,
   SitesService,
@@ -58,6 +60,7 @@ import { MatErrorMessagesDirective } from './utils/matErrorMessages.directive';
 import { SitesGroupsReslver } from './resolver/sites-groups.resolver';
 import { CreateSiteResolver } from './resolver/create-site.resolver';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
+import { ObjectsPermissionMonitorings } from './enum/objectPermission';
 // my module routing
 const routes: Routes = [
   /** modules  */
@@ -81,6 +84,14 @@ const routes: Routes = [
   {
     path: 'sites_group',
     component: MonitoringMapListComponent,
+    canActivate: [PermissionGuard],
+    data: {
+      expectedPermission: 'Read',
+      objectPermission: [
+        ObjectsPermissionMonitorings.GNM_GRP_SITES,
+        ObjectsPermissionMonitorings.GNM_SITES,
+      ],
+    },
     children: [
       {
         path: '',
@@ -89,7 +100,15 @@ const routes: Routes = [
           data: SitesGroupsReslver,
         },
       },
-      { path: 'create', component: MonitoringSitesGroupsCreateComponent },
+      {
+        path: 'create',
+        component: MonitoringSitesGroupsCreateComponent,
+        canActivate: [PermissionGuard],
+        data: {
+          expectedPermission: 'Create',
+          objectPermission: [ObjectsPermissionMonitorings.GNM_GRP_SITES],
+        },
+      },
       {
         path: ':id',
         children: [
@@ -200,6 +219,8 @@ const routes: Routes = [
     VisitsService,
     SitesGroupsReslver,
     CreateSiteResolver,
+    PermissionService,
+    PermissionGuard,
   ],
   bootstrap: [ModulesComponent],
   schemas: [

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -99,12 +99,6 @@ const routes: Routes = [
         resolve: {
           data: SitesGroupsReslver,
         },
-        // TODO: voir si on bloque l'accès en lecture
-        // canActivate: [PermissionGuard],
-        // data: {
-        //   expectedPermission: 'Read',
-        //   objectPermission: [ObjectsPermissionMonitorings.GNM_GRP_SITES],
-        // },
       },
       {
         path: 'create',
@@ -121,6 +115,13 @@ const routes: Routes = [
           {
             path: '',
             component: MonitoringSitesComponent,
+            canActivate: [PermissionGuard],
+            data: {
+              expectedPermission: 'Read',
+              objectPermission: [
+                ObjectsPermissionMonitorings.GNM_GRP_SITES,
+              ],
+            },
           },
           {
             path: 'create',
@@ -137,6 +138,13 @@ const routes: Routes = [
           {
             path: 'site/:id',
             component: MonitoringVisitsComponent,
+            canActivate: [PermissionGuard],
+            data: {
+              expectedPermission: 'Read',
+              objectPermission: [
+                ObjectsPermissionMonitorings.GNM_SITES,
+              ],
+            },
           },
         ],
       },
@@ -145,6 +153,13 @@ const routes: Routes = [
   {
     path: 'sites',
     component: MonitoringMapListComponent,
+    canActivate: [PermissionGuard],
+    data: {
+      expectedPermission: 'Read',
+      objectPermission: [
+        ObjectsPermissionMonitorings.GNM_SITES,
+      ],
+    },
     children: [
       {
         path: '',
@@ -158,6 +173,11 @@ const routes: Routes = [
         component: MonitoringSitesCreateComponent,
         resolve: {
           data: CreateSiteResolver,
+        },
+        canActivate: [PermissionGuard],
+        data: {
+          expectedPermission: 'Create',
+          objectPermission: [ObjectsPermissionMonitorings.GNM_SITES],
         },
       },
       {

--- a/frontend/app/interfaces/permission.ts
+++ b/frontend/app/interfaces/permission.ts
@@ -1,0 +1,6 @@
+export interface IPermission {
+  canCreate: boolean;
+  canRead: boolean;
+  canUpdate: boolean;
+  canDelete: boolean;
+}

--- a/frontend/app/resolver/sites-groups.resolver.ts
+++ b/frontend/app/resolver/sites-groups.resolver.ts
@@ -5,8 +5,11 @@ import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/r
 import { ISite, ISitesGroup } from '../interfaces/geom';
 import { IPaginated } from '../interfaces/page';
 import { IobjObs } from '../interfaces/objObs';
-import { map, mergeMap } from 'rxjs/operators';
+import { concatMap, map, mergeMap } from 'rxjs/operators';
 import { ConfigJsonService } from '../services/config-json.service';
+import { PermissionService } from '../services/permission.service';
+import { TPermission } from '../types/permission';
+import { DataMonitoringObjectService } from '../services/data-monitoring-object.service';
 const LIMIT = 10;
 
 @Injectable({ providedIn: 'root' })
@@ -18,10 +21,14 @@ export class SitesGroupsReslver
       route: string;
     }>
 {
+  currentPermission: TPermission;
+
   constructor(
     public service: SitesGroupService,
     public serviceSite: SitesService,
-    public _configJsonService: ConfigJsonService
+    public _configJsonService: ConfigJsonService,
+    public _permissionService: PermissionService,
+    private _dataMonitoringObjectService: DataMonitoringObjectService
   ) {}
 
   resolve(
@@ -32,49 +39,69 @@ export class SitesGroupsReslver
     sites: { data: IPaginated<ISite>; objConfig: IobjObs<ISite> };
     route: string;
   }> {
+    const $getPermissionMonitoring = this._dataMonitoringObjectService.getCruvedMonitoring();
+    const $permissionUserObject = this._permissionService.currentPermissionObj;
     const $configSitesGroups = this.service.initConfig();
     const $configSites = this.serviceSite.initConfig();
 
-    const resolvedData = forkJoin([$configSitesGroups, $configSites]).pipe(
-      map((configs) => {
-        const configSchemaSiteGroup = this._configJsonService.configModuleObject(
-          configs[0].moduleCode,
-          configs[0].objectType
-        );
-
-        const configSchemaSite = this._configJsonService.configModuleObject(
-          configs[1].moduleCode,
-          configs[1].objectType
-        );
-
-        const sortSiteGroupInit =
-          'sorts' in configSchemaSiteGroup
-            ? {
-                sort_dir: configSchemaSiteGroup.sorts[0].dir,
-                sort: configSchemaSiteGroup.sorts[0].prop,
-              }
-            : {};
-        const sortSiteInit =
-          'sorts' in configSchemaSite
-            ? { sort_dir: configSchemaSite.sorts[0].dir, sort: configSchemaSite.sorts[0].prop }
-            : {};
-
-        const $getSiteGroups = this.service.get(1, LIMIT, sortSiteGroupInit);
-        const $getSites = this.serviceSite.get(1, LIMIT, sortSiteInit);
-
-        return forkJoin([$getSiteGroups, $getSites]).pipe(
-          map(([siteGroups, sites]) => {
-            return {
-              sitesGroups: { data: siteGroups, objConfig: configs[0] },
-              sites: { data: sites, objConfig: configs[1] },
-              route: route['_urlSegment'].segments[1].path,
-            };
-          })
-        );
+    const resolvedData = $getPermissionMonitoring.pipe(
+      map((listObjectCruved: Object) => {
+        this._permissionService.setPermissionMonitorings(listObjectCruved);
       }),
-      mergeMap((result) => {
-        return result;
-      })
+      concatMap(() =>
+        $permissionUserObject.pipe(
+          map((permissionObject: TPermission) => (this.currentPermission = permissionObject))
+        )
+      ),
+      concatMap(() =>
+        forkJoin([$configSitesGroups, $configSites]).pipe(
+          map((configs) => {
+            const configSchemaSiteGroup = this._configJsonService.configModuleObject(
+              configs[0].moduleCode,
+              configs[0].objectType
+            );
+
+            const configSchemaSite = this._configJsonService.configModuleObject(
+              configs[1].moduleCode,
+              configs[1].objectType
+            );
+
+            const sortSiteGroupInit =
+              'sorts' in configSchemaSiteGroup
+                ? {
+                    sort_dir: configSchemaSiteGroup.sorts[0].dir,
+                    sort: configSchemaSiteGroup.sorts[0].prop,
+                  }
+                : {};
+            const sortSiteInit =
+              'sorts' in configSchemaSite
+                ? { sort_dir: configSchemaSite.sorts[0].dir, sort: configSchemaSite.sorts[0].prop }
+                : {};
+
+            const $getSiteGroups = this.currentPermission.GNM_GRP_SITES.canRead
+              ? this.service.get(1, LIMIT, sortSiteGroupInit)
+              : of({ items: [], count: 0, limit: 0, page: 1 });
+            // const $getSiteGroups = this.service.get(1, LIMIT, sortSiteGroupInit)
+            const $getSites = this.currentPermission.GNM_SITES.canRead
+              ? this.serviceSite.get(1, LIMIT, sortSiteInit)
+              : of({ items: [], count: 0, limit: 0, page: 1 });
+
+            return forkJoin([$getSiteGroups, $getSites]).pipe(
+              map(([siteGroups, sites]) => {
+                return {
+                  sitesGroups: { data: siteGroups, objConfig: configs[0] },
+                  sites: { data: sites, objConfig: configs[1] },
+                  route: route['_urlSegment'].segments[1].path,
+                  permission: this.currentPermission,
+                };
+              })
+            );
+          }),
+          mergeMap((result) => {
+            return result;
+          })
+        )
+      )
     );
     return resolvedData;
   }

--- a/frontend/app/services/data-monitoring-object.service.ts
+++ b/frontend/app/services/data-monitoring-object.service.ts
@@ -18,12 +18,19 @@ export class DataMonitoringObjectService {
     private _config: ConfigService
   ) {}
 
+  /**
+   * Renvoie la liste des cruved object liés à Monitorings et de l'utilisateur connecté
+   */
+  getCruvedMonitoring() {
+    return this._cacheService.request('get', `cruved_object`);
+  }
+
   /** Modules */
 
   /**
    * Renvoie la liste des modules
    */
-  getModules() {
+  getModules(): Array<any> {
     return this._cacheService.request('get', `modules`);
   }
 

--- a/frontend/app/services/form.service.ts
+++ b/frontend/app/services/form.service.ts
@@ -100,7 +100,7 @@ export class FormService {
       concatMap((formValues_in) => {
         const formValues = Utils.copy(formValues_in);
         // geometry
-        if (obj.config['geometry_type']) {
+        if ('config' in obj && obj.config['geometry_type']) {
           // TODO: change null by the geometry load from the object (if edit) or null if create
           // formValues["geometry"] = this.geometry; // copy???
           formValues['geometry'] = obj.geometry; // copy???

--- a/frontend/app/services/permission.guard.ts
+++ b/frontend/app/services/permission.guard.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { Router, CanActivate, ActivatedRouteSnapshot } from '@angular/router';
+import { CommonService } from '@geonature_common/service/common.service';
+import { PermissionService } from './permission.service';
+import { ObjectsPermissionMonitorings } from '../enum/objectPermission';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class PermissionGuard implements CanActivate {
+  constructor(
+    public router: Router,
+    private _permissionService: PermissionService,
+    public commonService: CommonService
+  ) {}
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    let routeData = route.data;
+    return this.checkPermission(routeData);
+  }
+
+  checkPermission(routeData): Observable<boolean> {
+    return this._permissionService.currentPermissionObj.pipe(
+      map((permissionUserObject) => {
+        let isAllowed: boolean = false;
+        const expectedPermission = routeData.expectedPermission;
+        const objectPermission: ObjectsPermissionMonitorings[] = routeData.objectPermission;
+
+        switch (expectedPermission) {
+          case 'Read':
+            isAllowed = objectPermission.some((objectPerm) => {
+              return permissionUserObject[objectPerm].canRead == true;
+            });
+            break;
+          case 'Create':
+            isAllowed = objectPermission.some((objectPerm) => {
+              return permissionUserObject[objectPerm].canCreate == true;
+            });
+            break;
+          case 'Update':
+            isAllowed = objectPermission.some((objectPerm) => {
+              return permissionUserObject[objectPerm].canUpdate == true;
+            });
+            break;
+        }
+
+        if (!isAllowed) {
+          this.commonService.translateToaster(
+            'warning',
+            "Vous n'avez pas les droits pour accéder à la page"
+          );
+        }
+        return isAllowed;
+      })
+    );
+  }
+}

--- a/frontend/app/services/permission.guard.ts
+++ b/frontend/app/services/permission.guard.ts
@@ -33,16 +33,15 @@ export class PermissionGuard implements CanActivate {
             break;
           case 'Create':
             isAllowed = objectPermission.some((objectPerm) => {
-              return permissionUserObject[objectPerm].canCreate == true;
+              return permissionUserObject[objectPerm].canCreate == true && permissionUserObject[objectPerm].canRead == true ;
             });
             break;
           case 'Update':
             isAllowed = objectPermission.some((objectPerm) => {
-              return permissionUserObject[objectPerm].canUpdate == true;
+              return permissionUserObject[objectPerm].canUpdate == true  && permissionUserObject[objectPerm].canRead == true;
             });
             break;
         }
-
         if (!isAllowed) {
           this.commonService.translateToaster(
             'warning',

--- a/frontend/app/services/permission.service.ts
+++ b/frontend/app/services/permission.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TPermission } from '../types/permission';
-import { BehaviorSubject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 import { ObjectsPermissionMonitorings } from '../enum/objectPermission';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class PermissionService {
 
   constructor() {}
 
-  private permissionObject = new BehaviorSubject<TPermission>(this.defaultPermission);
+  private permissionObject = new ReplaySubject<TPermission>();
   currentPermissionObj = this.permissionObject.asObservable();
 
   setPermissionUser(permUser: TPermission) {

--- a/frontend/app/services/permission.service.ts
+++ b/frontend/app/services/permission.service.ts
@@ -38,20 +38,16 @@ export class PermissionService {
       Object.keys(listObjectCruved[objKey]).forEach((action) => {
         switch (action) {
           case 'C':
-            this.defaultPermission[objKey].canCreate =
-              listObjectCruved[objKey][action] > 0 ? true : false;
+            this.defaultPermission[objKey].canCreate = listObjectCruved[objKey][action];
             break;
           case 'R':
-            this.defaultPermission[objKey].canRead =
-              listObjectCruved[objKey][action] > 0 ? true : false;
+            this.defaultPermission[objKey].canRead = listObjectCruved[objKey][action];
             break;
           case 'U':
-            this.defaultPermission[objKey].canUpdate =
-              listObjectCruved[objKey][action] > 0 ? true : false;
+            this.defaultPermission[objKey].canUpdate = listObjectCruved[objKey][action];
             break;
           case 'D':
-            this.defaultPermission[objKey].canDelete =
-              listObjectCruved[objKey][action] > 0 ? true : false;
+            this.defaultPermission[objKey].canDelete = listObjectCruved[objKey][action];
             break;
           default:
             break;

--- a/frontend/app/services/permission.service.ts
+++ b/frontend/app/services/permission.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { TPermission } from '../types/permission';
+import { BehaviorSubject } from 'rxjs';
+import { ObjectsPermissionMonitorings } from '../enum/objectPermission';
+
+@Injectable()
+export class PermissionService {
+  defaultPermission: TPermission = {
+    [ObjectsPermissionMonitorings.GNM_GRP_SITES]: {
+      canCreate: false,
+      canRead: false,
+      canUpdate: false,
+      canDelete: false,
+    },
+    [ObjectsPermissionMonitorings.GNM_SITES]: {
+      canCreate: false,
+      canRead: false,
+      canUpdate: false,
+      canDelete: false,
+    },
+  };
+
+  constructor() {}
+
+  private permissionObject = new BehaviorSubject<TPermission>(this.defaultPermission);
+  currentPermissionObj = this.permissionObject.asObservable();
+
+  setPermissionUser(permUser: TPermission) {
+    this.permissionObject.next(permUser);
+  }
+
+  setPermissionMonitorings(listObjectCruved) {
+    Object.keys(this.defaultPermission).forEach((objKey) => {
+      this.defaultPermission[objKey].canRead = false;
+      this.defaultPermission[objKey].canCreate = false;
+      this.defaultPermission[objKey].canDelete = false;
+      this.defaultPermission[objKey].canUpdate = false;
+      Object.keys(listObjectCruved[objKey]).forEach((action) => {
+        switch (action) {
+          case 'C':
+            this.defaultPermission[objKey].canCreate =
+              listObjectCruved[objKey][action] > 0 ? true : false;
+            break;
+          case 'R':
+            this.defaultPermission[objKey].canRead =
+              listObjectCruved[objKey][action] > 0 ? true : false;
+            break;
+          case 'U':
+            this.defaultPermission[objKey].canUpdate =
+              listObjectCruved[objKey][action] > 0 ? true : false;
+            break;
+          case 'D':
+            this.defaultPermission[objKey].canDelete =
+              listObjectCruved[objKey][action] > 0 ? true : false;
+            break;
+          default:
+            break;
+        }
+      });
+    });
+    this.setPermissionUser(this.defaultPermission);
+  }
+}

--- a/frontend/app/types/permission.ts
+++ b/frontend/app/types/permission.ts
@@ -1,0 +1,4 @@
+import { ObjectsPermissionMonitorings } from '../enum/objectPermission';
+import { IPermission } from '../interfaces/permission';
+
+export type TPermission = Record<ObjectsPermissionMonitorings, IPermission>;


### PR DESCRIPTION
Ajout des permissions avec portée (mes données , mon organisme )

BACK:
-  Ajout de fonction qui permet d'ajouter un "cruved" a chaque instance de class site, sites_group, visit, observation 
- Protection des routes via l'ajout des décorateurs `permission.check_cruved_scope` pour pouvoir récupérer le scope et renvoyer un Fobridden en fonction des droits sur la route en question (read, create, update, delete)
- Ajout d'une fonction permettant de filtrer sur la liste d'objet (route GET site, sites_groups, visit, observation) permettant de ne renvoyer uniquement la liste d'objet dont l'utilisateur à les permissions de lecture

FRONT:
- Ajout de `canAcitvate` sur les routes d'accès aux sites/groupes de sites (entrée par site) :
   * Ainsi si l'utilisteur à un des deux droits de lecture sur les objets code : GNM_GRP_SITES  et GNM_SITES pour le module_code MONITORINGS alors il a le bouton de "Accès aux sites" est disponible . S'il n'a aucune permissions sur ces deux objets alors le bouton "accès aux sites" est grisé avec comme info bulle "Vous n'avez pas les droits nécessaires" . 
    * SI l'utilisateur tente d'accéder directement via l'url aux routes coté frontend alors un message d'alerte est renvoyé directement pour avertir l'utilisateur qu'il n'a pas les permissions nécessaires d'accès à la plage
- Les boutons et icones  d'édition , de suppression , de création  sont grisés et l'info bulle "Vous n'avez pas les permissions nécessires" sont affichés à l'utilisateur 
    
