### PR TITLE
Feat/migrations and orm

### DIFF
--- a/backend/gn_module_monitoring/migrations/0790c7d024fb_add_individuals.py
+++ b/backend/gn_module_monitoring/migrations/0790c7d024fb_add_individuals.py
@@ -1,0 +1,135 @@
+"""add individuals
+
+Revision ID: 0790c7d024fb
+Revises: fc90d31c677f
+Create Date: 2023-09-27 14:01:26.035798
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+
+# revision identifiers, used by Alembic.
+revision = "0790c7d024fb"
+down_revision = "fc90d31c677f"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "gn_monitoring"
+
+
+def upgrade():
+    op.create_table(
+        "t_base_individuals",
+        sa.Column("id_base_individual", sa.Integer, primary_key=True),
+        sa.Column(
+            "uuid_individual", UUID, nullable=False, server_default=sa.text("uuid_generate_v4()")
+        ),
+        sa.Column("base_individual_name", sa.Unicode(255), nullable=False),
+        sa.Column("cd_nom", sa.Integer, sa.ForeignKey("taxonomie.taxref.cd_nom"), nullable=False),
+        sa.Column(
+            "id_nomenclature_sex",
+            sa.Integer,
+            sa.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature"),
+            server_default=sa.text(
+                "ref_nomenclatures.get_default_nomenclature_value('SEXE'::character varying)"
+            ),
+        ),
+        sa.Column("active", sa.Boolean, server_default=sa.sql.true()),
+        sa.Column("comment", sa.Text),
+        sa.Column(
+            "id_digitiser",
+            sa.Integer,
+            sa.ForeignKey("utilisateurs.t_roles.id_role"),
+            nullable=False,
+        ),
+        sa.Column("meta_create_date", sa.DateTime(timezone=False)),
+        sa.Column("meta_update_date", sa.DateTime(timezone=False)),
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "t_marking_events",
+        sa.Column("id_marking", sa.Integer, primary_key=True),
+        sa.Column(
+            "id_base_individual",
+            sa.Integer,
+            sa.ForeignKey(f"{SCHEMA}.t_base_individuals.id_base_individual", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("marking_date", sa.DateTime(timezone=False), nullable=False),
+        sa.Column(
+            "id_operator",
+            sa.Integer,
+            sa.ForeignKey("utilisateurs.t_roles.id_role"),
+            nullable=False,
+        ),
+        sa.Column(
+            "id_base_marking_site",
+            sa.Integer,
+            sa.ForeignKey("gn_monitoring.t_base_sites.id_base_site"),
+        ),
+        sa.Column(
+            "id_nomenclature_marking_type",
+            sa.Integer,
+            sa.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature"),
+            nullable=False,
+        ),
+        sa.Column("marking_location", sa.Unicode(255)),
+        sa.Column("marking_code", sa.Unicode(255)),
+        sa.Column("marking_details", sa.Text),
+        sa.Column("additional_data", JSONB),
+        sa.Column(
+            "id_digitiser",
+            sa.Integer,
+            sa.ForeignKey("utilisateurs.t_roles.id_role"),
+            nullable=False,
+        ),
+        sa.Column("meta_create_date", sa.DateTime(timezone=False)),
+        sa.Column("meta_update_date", sa.DateTime(timezone=False)),
+        schema=SCHEMA,
+    )
+    # TODO: add constraint to id_nomenclature_marking_type to check
+
+    op.create_table(
+        "t_individual_complements",
+        sa.Column(
+            "id_base_individual",
+            sa.Integer,
+            sa.ForeignKey(f"{SCHEMA}.t_base_individuals.id_base_individual", ondelete="CASCADE"),
+            primary_key=True
+        ),
+        sa.Column(
+            "id_module",
+            sa.Integer,
+            sa.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
+            primary_key=True
+        ),
+        sa.Column("data", JSONB),
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "cor_individual_module",
+        sa.Column(
+            "id_base_individual",
+            sa.Integer,
+            sa.ForeignKey(f"{SCHEMA}.t_base_individuals.id_base_individual", ondelete="CASCADE"),
+            primary_key=True
+        ),
+        sa.Column(
+            "id_module",
+            sa.Integer,
+            sa.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
+            primary_key=True
+        ),
+        schema=SCHEMA,
+    )
+
+
+def downgrade():
+    op.drop_table("cor_individual_module", schema=SCHEMA)
+    op.drop_table("t_individual_complements", schema=SCHEMA)
+    op.drop_table("t_marking_events", schema=SCHEMA)
+    op.drop_table("t_base_individuals", schema=SCHEMA)

--- a/backend/gn_module_monitoring/migrations/0790c7d024fb_add_individuals.py
+++ b/backend/gn_module_monitoring/migrations/0790c7d024fb_add_individuals.py
@@ -7,104 +7,32 @@ Create Date: 2023-09-27 14:01:26.035798
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import JSONB
 
 
 # revision identifiers, used by Alembic.
 revision = "0790c7d024fb"
 down_revision = "fc90d31c677f"
 branch_labels = None
-depends_on = None
+depends_on = "84f40d008640"  # individuals (geonature)
 
 SCHEMA = "gn_monitoring"
 
 
 def upgrade():
     op.create_table(
-        "t_base_individuals",
-        sa.Column("id_base_individual", sa.Integer, primary_key=True),
-        sa.Column(
-            "uuid_individual", UUID, nullable=False, server_default=sa.text("uuid_generate_v4()")
-        ),
-        sa.Column("base_individual_name", sa.Unicode(255), nullable=False),
-        sa.Column("cd_nom", sa.Integer, sa.ForeignKey("taxonomie.taxref.cd_nom"), nullable=False),
-        sa.Column(
-            "id_nomenclature_sex",
-            sa.Integer,
-            sa.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature"),
-            server_default=sa.text(
-                "ref_nomenclatures.get_default_nomenclature_value('SEXE'::character varying)"
-            ),
-        ),
-        sa.Column("active", sa.Boolean, server_default=sa.sql.true()),
-        sa.Column("comment", sa.Text),
-        sa.Column(
-            "id_digitiser",
-            sa.Integer,
-            sa.ForeignKey("utilisateurs.t_roles.id_role"),
-            nullable=False,
-        ),
-        sa.Column("meta_create_date", sa.DateTime(timezone=False)),
-        sa.Column("meta_update_date", sa.DateTime(timezone=False)),
-        schema=SCHEMA,
-    )
-
-    op.create_table(
-        "t_marking_events",
-        sa.Column("id_marking", sa.Integer, primary_key=True),
-        sa.Column(
-            "id_base_individual",
-            sa.Integer,
-            sa.ForeignKey(f"{SCHEMA}.t_base_individuals.id_base_individual", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("marking_date", sa.DateTime(timezone=False), nullable=False),
-        sa.Column(
-            "id_operator",
-            sa.Integer,
-            sa.ForeignKey("utilisateurs.t_roles.id_role"),
-            nullable=False,
-        ),
-        sa.Column(
-            "id_base_marking_site",
-            sa.Integer,
-            sa.ForeignKey("gn_monitoring.t_base_sites.id_base_site"),
-        ),
-        sa.Column(
-            "id_nomenclature_marking_type",
-            sa.Integer,
-            sa.ForeignKey("ref_nomenclatures.t_nomenclatures.id_nomenclature"),
-            nullable=False,
-        ),
-        sa.Column("marking_location", sa.Unicode(255)),
-        sa.Column("marking_code", sa.Unicode(255)),
-        sa.Column("marking_details", sa.Text),
-        sa.Column("additional_data", JSONB),
-        sa.Column(
-            "id_digitiser",
-            sa.Integer,
-            sa.ForeignKey("utilisateurs.t_roles.id_role"),
-            nullable=False,
-        ),
-        sa.Column("meta_create_date", sa.DateTime(timezone=False)),
-        sa.Column("meta_update_date", sa.DateTime(timezone=False)),
-        schema=SCHEMA,
-    )
-    # TODO: add constraint to id_nomenclature_marking_type to check
-
-    op.create_table(
         "t_individual_complements",
         sa.Column(
             "id_base_individual",
             sa.Integer,
             sa.ForeignKey(f"{SCHEMA}.t_base_individuals.id_base_individual", ondelete="CASCADE"),
-            primary_key=True
+            primary_key=True,
         ),
         sa.Column(
             "id_module",
             sa.Integer,
             sa.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
-            primary_key=True
+            primary_key=True,
         ),
         sa.Column("data", JSONB),
         schema=SCHEMA,
@@ -116,13 +44,13 @@ def upgrade():
             "id_base_individual",
             sa.Integer,
             sa.ForeignKey(f"{SCHEMA}.t_base_individuals.id_base_individual", ondelete="CASCADE"),
-            primary_key=True
+            primary_key=True,
         ),
         sa.Column(
             "id_module",
             sa.Integer,
             sa.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
-            primary_key=True
+            primary_key=True,
         ),
         schema=SCHEMA,
     )
@@ -131,5 +59,3 @@ def upgrade():
 def downgrade():
     op.drop_table("cor_individual_module", schema=SCHEMA)
     op.drop_table("t_individual_complements", schema=SCHEMA)
-    op.drop_table("t_marking_events", schema=SCHEMA)
-    op.drop_table("t_base_individuals", schema=SCHEMA)

--- a/backend/gn_module_monitoring/monitoring/definitions.py
+++ b/backend/gn_module_monitoring/monitoring/definitions.py
@@ -5,6 +5,7 @@ from .models import (
     TMonitoringObservations,
     TMonitoringObservationDetails,
     TMonitoringSitesGroups,
+    TMonitoringIndividuals,
 )
 from .objects import MonitoringModule, MonitoringSite
 
@@ -26,6 +27,7 @@ MonitoringModels_dict = {
     "observation": TMonitoringObservations,
     "observation_detail": TMonitoringObservationDetails,
     "sites_group": TMonitoringSitesGroups,
+    "individual": TMonitoringIndividuals,
 }
 
 MonitoringObjects_dict = {
@@ -35,6 +37,7 @@ MonitoringObjects_dict = {
     "observation": MonitoringObject,
     "observation_detail": MonitoringObject,
     "sites_group": MonitoringObjectGeom,
+    "individual": MonitoringObject,
 }
 
 MonitoringPermissions_dict = {

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -240,6 +240,23 @@ class TMonitoringSitesGroups(DB.Model):
     )
 
 
+corIndividualModule = DB.Table(
+    "cor_individual_module",
+    DB.Column(
+        "id_base_individual",
+        DB.Integer,
+        DB.ForeignKey("gn_monitoring.t_individual_complements.id_base_individual", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    DB.Column(
+        "id_module",
+        DB.Integer,
+        DB.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    schema="gn_monitoring",
+)
+
 @serializable
 class TMonitoringIndividuals(TMarkingEvent):
     __tablename__ = "t_individual_complements"
@@ -264,23 +281,16 @@ class TMonitoringIndividuals(TMarkingEvent):
 
     data = DB.Column(JSONB)
 
-
-# corIndividualModule = DB.Table(
-#     "cor_individual_module",
-#     DB.Column(
-#         "id_base_individual",
-#         DB.Integer,
-#         DB.ForeignKey("gn_monitoring.t_base_individuals.id_base_individual", ondelete="CASCADE"),
-#         primary_key=True,
-#     ),
-#     DB.Column(
-#         "id_module",
-#         DB.Integer,
-#         DB.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
-#         primary_key=True,
-#     ),
-#     schema="gn_monitoring",
-# )
+    
+    modules = DB.relationship(
+        "TModules",
+        lazy="select",
+        enable_typechecks=False,
+        secondary=corIndividualModule,
+        primaryjoin=(corIndividualModule.c.id_base_individual == id_base_individual),
+        secondaryjoin=(corIndividualModule.c.id_module == TModules.id_module),
+        foreign_keys=[corIndividualModule.c.id_base_individual, corIndividualModule.c.id_module],
+    )
 
 
 @serializable
@@ -339,12 +349,13 @@ class TMonitoringModules(TModules):
 
     individuals = DB.relationship(
         "TMonitoringIndividuals",
-        uselist=True,  # pourquoi pas par defaut ?
-        primaryjoin=TMonitoringIndividuals.id_module == id_module,
-        foreign_keys=[id_module],
         lazy="select",
+        enable_typechecks=False,
+        secondary=corIndividualModule,
+        primaryjoin=(corIndividualModule.c.id_module == id_module),
+        secondaryjoin=(corIndividualModule.c.id_base_individual == TMonitoringIndividuals.id_base_individual),
+        foreign_keys=[corIndividualModule.c.id_base_individual, corIndividualModule.c.id_module],
     )
-
     data = DB.Column(JSONB)
 
     # visits = DB.relationship(

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 
 from geonature.core.gn_commons.models import TMedias
-from geonature.core.gn_monitoring.models import TBaseSites, TBaseVisits
+from geonature.core.gn_monitoring.models import TBaseSites, TBaseVisits, TMarkingEvent
 from geonature.core.gn_meta.models import TDatasets
 from geonature.utils.env import DB
 from geonature.core.gn_commons.models import TModules, cor_module_dataset
@@ -241,6 +241,49 @@ class TMonitoringSitesGroups(DB.Model):
 
 
 @serializable
+class TMonitoringIndividuals(TMarkingEvent):
+    __tablename__ = "t_individual_complements"
+    __table_args__ = {"schema": "gn_monitoring"}
+    __mapper_args__ = {
+        "polymorphic_identity": "monitoring_individuals",
+    }
+
+    id_base_individual = DB.Column(
+        DB.ForeignKey("gn_monitoring.t_marking_events.id_base_individual"),
+        primary_key=True,
+        nullable=False,
+        unique=True,
+    )
+
+    id_module = DB.Column(
+        DB.ForeignKey("gn_commons.t_modules.id_module"),
+        primary_key=True,
+        nullable=False,
+        unique=True,
+    )
+
+    data = DB.Column(JSONB)
+
+
+# corIndividualModule = DB.Table(
+#     "cor_individual_module",
+#     DB.Column(
+#         "id_base_individual",
+#         DB.Integer,
+#         DB.ForeignKey("gn_monitoring.t_base_individuals.id_base_individual", ondelete="CASCADE"),
+#         primary_key=True,
+#     ),
+#     DB.Column(
+#         "id_module",
+#         DB.Integer,
+#         DB.ForeignKey("gn_commons.t_modules.id_module", ondelete="CASCADE"),
+#         primary_key=True,
+#     ),
+#     schema="gn_monitoring",
+# )
+
+
+@serializable
 class TMonitoringModules(TModules):
     __tablename__ = "t_module_complements"
     __table_args__ = {"schema": "gn_monitoring"}
@@ -292,6 +335,14 @@ class TMonitoringModules(TModules):
         secondary=cor_module_dataset,
         join_depth=0,
         lazy="joined",
+    )
+
+    individuals = DB.relationship(
+        "TMonitoringIndividuals",
+        uselist=True,  # pourquoi pas par defaut ?
+        primaryjoin=TMonitoringIndividuals.id_module == id_module,
+        foreign_keys=[id_module],
+        lazy="select",
     )
 
     data = DB.Column(JSONB)


### PR DESCRIPTION
Ajout de la migration ajoutant des tables spécifiques aux individus dans monitoring. Attention ! Dépend de la migration d'initialisation des individus dans GN
Ajout des modèles ORM. Attention ! Dépend de la PR https://github.com/PnX-SI/GeoNature/pull/2740 de GeoNature
Premiers ajouts d'éléments de configuration des modèles dans monitoring