### PR TITLE
Feat/geometry site groups

### DIFF
--- a/backend/gn_module_monitoring/config/generic/sites_group.json
+++ b/backend/gn_module_monitoring/config/generic/sites_group.json
@@ -6,6 +6,8 @@
     "label_list": "Groupes de sites",
     "genre": "M",
     "uuid_field_name": "uuid_sites_group",
+    "geom_field_name": "geom",
+    "geometry_type": "Polygon",
     "display_properties": [
       "sites_group_name",
       "sites_group_code",
@@ -53,6 +55,21 @@
         "type_widget": "medias",
         "attribut_label": "Médias",
         "schema_dot_table": "gn_monitoring.t_sites_groups"
-      }
-    }
+      },
+      "altitude_min": {
+        "type_widget": "integer",
+        "attribut_label": "Altitude (min)"
+        },
+      "altitude_max": {
+        "type_widget": "integer",
+        "attribut_label": "Altitude (max)"
+        },
+        "id_digitiser": {
+          "type_widget": "text",
+          "attribut_label": "Digitiser",
+          "type_util": "user",
+          "required": true,
+          "hidden": true
+        }
+    } 
   }

--- a/backend/gn_module_monitoring/migrations/f3413cccdfa8_add_geom_column_to_sites_group.py
+++ b/backend/gn_module_monitoring/migrations/f3413cccdfa8_add_geom_column_to_sites_group.py
@@ -1,0 +1,126 @@
+"""add geom column to sites_group
+
+Revision ID: f3413cccdfa8
+Revises: f24adb481f54
+Create Date: 2023-09-26 10:57:18.886119
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+
+# revision identifiers, used by Alembic.
+revision = 'f3413cccdfa8'
+down_revision = 'f24adb481f54'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        ALTER TABLE gn_monitoring.t_sites_groups
+        ADD COLUMN geom
+            public.geometry(geometry, 4326) NULL,
+        ADD COLUMN geom_local
+            public.geometry(geometry, 2154) NULL,
+        ADD COLUMN altitude_min
+                int4 NULL,
+        ADD COLUMN altitude_max
+                int4 NULL;
+        """
+    )
+
+    # version sqlalchemy
+    # op.add_column(
+    # schema="gn_monitoring",
+    #     table_name="t_sites_groups",
+    #     column=sa.Column(
+    #         "geom",
+    #         geoalchemy2.types.Geometry(geometry_type='GEOMETRY'),
+    #         nullable=True,
+    #     )
+    # )
+
+    # op.add_column(
+    # schema="gn_monitoring",
+    #     table_name="t_sites_groups",
+    #     column=sa.Column(
+    #         "geom_local",
+    #         geoalchemy2.types.Geometry(geometry_type='GEOMETRY'),
+    #         nullable=True,
+    #     )
+    # )
+
+    op.execute(
+        """
+        ALTER TABLE gn_monitoring.t_sites_groups
+	        ADD CONSTRAINT enforce_srid_geom CHECK ((st_srid(geom) = 4326));
+        """
+
+    )
+
+    op.execute(
+        """
+        CREATE INDEX idx_t_sites_groups_geom ON gn_monitoring.t_sites_groups USING gist (geom);
+        """
+    )
+
+    op.execute(
+         """
+        create trigger tri_calculate_geom_local before
+        insert
+            or
+        update
+            on
+            gn_monitoring.t_sites_groups for each row execute function ref_geo.fct_trg_calculate_geom_local('geom',
+            'geom_local');
+        create trigger tri_t_sites_groups_calculate_alt before
+        insert
+            or
+        update
+            on
+            gn_monitoring.t_sites_groups for each row execute function ref_geo.fct_trg_calculate_alt_minmax('geom');
+        create trigger tri_insert_calculate_altitude before
+        insert
+            on
+            gn_monitoring.t_sites_groups for each row execute function ref_geo.fct_trg_calculate_alt_minmax('geom');
+        create trigger tri_update_calculate_altitude before
+        update
+            of geom_local,
+            geom on
+            gn_monitoring.t_sites_groups for each row execute function ref_geo.fct_trg_calculate_alt_minmax('geom');
+
+         """       
+
+    )
+
+
+def downgrade():
+
+    op.execute(
+        """
+        DROP TRIGGER tri_calculate_geom_local
+            ON gn_monitoring.t_sites_groups;
+        DROP TRIGGER tri_t_sites_groups_calculate_alt
+            ON gn_monitoring.t_sites_groups;
+        DROP TRIGGER tri_insert_calculate_altitude
+            ON gn_monitoring.t_sites_groups;
+        DROP TRIGGER tri_update_calculate_altitude
+            ON gn_monitoring.t_sites_groups;
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE gn_monitoring.t_sites_groups
+        DROP COLUMN geom,
+        DROP COLUMN geom_local,
+        DROP COLUMN altitude_min,
+        DROP COLUMN altitude_max;
+        """
+        )
+    
+
+
+

--- a/backend/gn_module_monitoring/migrations/f3413cccdfa8_add_geom_column_to_sites_group.py
+++ b/backend/gn_module_monitoring/migrations/f3413cccdfa8_add_geom_column_to_sites_group.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 import geoalchemy2
 
 # revision identifiers, used by Alembic.
-revision = 'f3413cccdfa8'
-down_revision = 'f24adb481f54'
+revision = "f3413cccdfa8"
+down_revision = "f24adb481f54"
 branch_labels = None
 depends_on = None
 
@@ -57,7 +57,6 @@ def upgrade():
         ALTER TABLE gn_monitoring.t_sites_groups
 	        ADD CONSTRAINT enforce_srid_geom CHECK ((st_srid(geom) = 4326));
         """
-
     )
 
     op.execute(
@@ -67,7 +66,7 @@ def upgrade():
     )
 
     op.execute(
-         """
+        """
         create trigger tri_calculate_geom_local before
         insert
             or
@@ -91,13 +90,11 @@ def upgrade():
             geom on
             gn_monitoring.t_sites_groups for each row execute function ref_geo.fct_trg_calculate_alt_minmax('geom');
 
-         """       
-
+         """
     )
 
 
 def downgrade():
-
     op.execute(
         """
         DROP TRIGGER tri_calculate_geom_local
@@ -119,8 +116,4 @@ def downgrade():
         DROP COLUMN altitude_min,
         DROP COLUMN altitude_max;
         """
-        )
-    
-
-
-
+    )

--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -37,8 +37,10 @@ from gn_module_monitoring.monitoring.queries import (
     ObservationsQuery,
 )
 from geonature.core.gn_permissions.tools import has_any_permissions_by_action
+
 # from geoalchemy2 import Geometry
 import geoalchemy2
+
 
 class GenericModel:
     @declared_attr
@@ -434,7 +436,7 @@ class TMonitoringSitesGroups(DB.Model, PermissionModel):
     sites_group_description = DB.Column(DB.Unicode)
 
     comments = DB.Column(DB.Unicode)
-    geom = DB.Column(geoalchemy2.types.Geometry("GEOMETRY", 4326,nullable=True))
+    geom = DB.Column(geoalchemy2.types.Geometry("GEOMETRY", 4326, nullable=True))
     data = DB.Column(JSONB)
 
     medias = DB.relationship(
@@ -483,8 +485,8 @@ class TMonitoringSitesGroups(DB.Model, PermissionModel):
     #             .where(
     #                 TMonitoringSites.id_sites_group == self.id_sites_group,
     #             )
-    #     )   
-    #     else:    
+    #     )
+    #     else:
     #         return column_property(
     #         select([func.st_asgeojson(self.geom)])
     #         )
@@ -670,15 +672,14 @@ TMonitoringSitesGroups.geom_geojson = column_property(select([func.st_asgeojson(
         TMonitoringSites.id_sites_group == TMonitoringSitesGroups.id_sites_group,
     )
 )
-    
-    # case([(TMonitoringSitesGroups.geom is None, select([func.st_asgeojson(func.st_convexHull(func.st_collect(TBaseSites.geom)))])
-    #             .select_from(
-    #                 TMonitoringSitesGroups.__table__.alias("subquery").join(
-    #                     TMonitoringSites,
-    #                     TMonitoringSites.id_sites_group == TMonitoringSitesGroups.id_sites_group,
-    #                 )
-    #             )
-    #             .where(
-    #                 TMonitoringSites.id_sites_group == TMonitoringSitesGroups.id_sites_group,
-    #             )), (TMonitoringSitesGroups.geom is not None,select([func.st_asgeojson(TMonitoringSitesGroups.geom)]))]))
 
+# case([(TMonitoringSitesGroups.geom is None, select([func.st_asgeojson(func.st_convexHull(func.st_collect(TBaseSites.geom)))])
+#             .select_from(
+#                 TMonitoringSitesGroups.__table__.alias("subquery").join(
+#                     TMonitoringSites,
+#                     TMonitoringSites.id_sites_group == TMonitoringSitesGroups.id_sites_group,
+#                 )
+#             )
+#             .where(
+#                 TMonitoringSites.id_sites_group == TMonitoringSitesGroups.id_sites_group,
+#             )), (TMonitoringSitesGroups.geom is not None,select([func.st_asgeojson(TMonitoringSitesGroups.geom)]))]))

--- a/backend/gn_module_monitoring/monitoring/schemas.py
+++ b/backend/gn_module_monitoring/monitoring/schemas.py
@@ -30,21 +30,32 @@ class MonitoringSitesGroupsSchema(MA.SQLAlchemyAutoSchema):
 
     class Meta:
         model = TMonitoringSitesGroups
-        exclude = ("geom_geojson",)
+        exclude = ("geom_geojson","geom")
         load_instance = True
 
     medias = MA.Nested(MediaSchema, many=True)
     pk = fields.Method("set_pk", dump_only=True)
     geometry = fields.Method("serialize_geojson", dump_only=True)
     id_digitiser = fields.Method("get_id_digitiser")
+    is_geom_from_child = fields.Method("set_is_geom_from_child", dump_only=True)
 
     def get_id_digitiser(self, obj):
         return obj.id_digitiser
 
     def set_pk(self, obj):
         return self.Meta.model.get_id_name()
+    
+    def set_is_geom_from_child(self, obj):
+        if obj.geom is None and obj.geom_geojson is None:
+            return True
+        if obj.geom is not None:
+            return False
+        if obj.geom_geojson is not None:
+            return True
 
     def serialize_geojson(self, obj):
+        if obj.geom is not None:
+            return geojson.dumps(obj.as_geofeature().get("geometry"))
         if obj.geom_geojson is not None:
             return json.loads(obj.geom_geojson)
 

--- a/backend/gn_module_monitoring/monitoring/schemas.py
+++ b/backend/gn_module_monitoring/monitoring/schemas.py
@@ -30,7 +30,7 @@ class MonitoringSitesGroupsSchema(MA.SQLAlchemyAutoSchema):
 
     class Meta:
         model = TMonitoringSitesGroups
-        exclude = ("geom_geojson","geom")
+        exclude = ("geom_geojson", "geom")
         load_instance = True
 
     medias = MA.Nested(MediaSchema, many=True)
@@ -45,6 +45,14 @@ class MonitoringSitesGroupsSchema(MA.SQLAlchemyAutoSchema):
     def set_pk(self, obj):
         return self.Meta.model.get_id_name()
     
+    def set_is_geom_from_child(self, obj):
+        if obj.geom is None and obj.geom_geojson is None:
+            return True
+        if obj.geom is not None:
+            return False
+        if obj.geom_geojson is not None:
+            return True
+
     def set_is_geom_from_child(self, obj):
         if obj.geom is None and obj.geom_geojson is None:
             return True

--- a/backend/gn_module_monitoring/monitoring/serializer.py
+++ b/backend/gn_module_monitoring/monitoring/serializer.py
@@ -221,7 +221,9 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
             self.preprocess_data(properties)
 
         # ajout des données en base
-        if hasattr(self._model, "from_geofeature") and not (len(list(post_data)) == 1 and list(post_data)[0] == 'properties')  :
+        if hasattr(self._model, "from_geofeature") and not (
+            len(list(post_data)) == 1 and list(post_data)[0] == "properties"
+        ):
             for key in list(post_data):
                 if key not in ("properties", "geometry", "type"):
                     post_data.pop(key)

--- a/backend/gn_module_monitoring/monitoring/serializer.py
+++ b/backend/gn_module_monitoring/monitoring/serializer.py
@@ -221,7 +221,7 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
             self.preprocess_data(properties)
 
         # ajout des données en base
-        if hasattr(self._model, "from_geofeature"):
+        if hasattr(self._model, "from_geofeature") and not (len(list(post_data)) == 1 and list(post_data)[0] == 'properties')  :
             for key in list(post_data):
                 if key not in ("properties", "geometry", "type"):
                     post_data.pop(key)

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -83,8 +83,14 @@ def get_sites_group_by_id(scope, id_sites_group: int, object_type: str):
     schema = MonitoringSitesGroupsSchema()
     result = TMonitoringSitesGroups.query.get_or_404(id_sites_group)
     response = schema.dump(result)
-    response['cruved']=get_objet_with_permission_boolean([result], object_code="MONITORINGS_GRP_SITES")[0]['cruved']
-    response["geometry"]= json.loads(response["geometry"]) if response["geometry"] != None and isinstance(response["geometry"],str)  else  response["geometry"]
+    response["cruved"] = get_objet_with_permission_boolean(
+        [result], object_code="MONITORINGS_GRP_SITES"
+    )[0]["cruved"]
+    response["geometry"] = (
+        json.loads(response["geometry"])
+        if response["geometry"] != None and isinstance(response["geometry"], str)
+        else response["geometry"]
+    )
     return response
 
 
@@ -96,7 +102,8 @@ def get_sites_group_geometries(object_type: str):
     object_code = "MONITORINGS_GRP_SITES"
     query = TMonitoringSitesGroups.query
     query_allowed = query.filter_by_readable(object_code=object_code)
-    subquery_not_geom = (query_allowed.with_entities(
+    subquery_not_geom = (
+        query_allowed.with_entities(
             TMonitoringSitesGroups.id_sites_group,
             TMonitoringSitesGroups.sites_group_name,
             func.st_convexHull(func.st_collect(TMonitoringSites.geom)),
@@ -104,23 +111,26 @@ def get_sites_group_geometries(object_type: str):
         .group_by(TMonitoringSitesGroups.id_sites_group, TMonitoringSitesGroups.sites_group_name).join(
             TMonitoringSites,
             TMonitoringSites.id_sites_group == TMonitoringSitesGroups.id_sites_group,
-        ).filter(TMonitoringSitesGroups.geom == None)
+        )
+        .filter(TMonitoringSitesGroups.geom == None)
         .subquery()
     )
 
-    subquery_with_geom = (query_allowed.with_entities(
+    subquery_with_geom = (
+        query_allowed.with_entities(
             TMonitoringSitesGroups.id_sites_group,
             TMonitoringSitesGroups.sites_group_name,
             TMonitoringSitesGroups.geom,
-        ).filter(TMonitoringSitesGroups.geom != None)).subquery()
+        ).filter(TMonitoringSitesGroups.geom != None)
+    ).subquery()
 
     result_1 = geojson_query(subquery_not_geom)
     result_2 = geojson_query(subquery_with_geom)
-    if(result_1['features'] is not None):
-        if(result_2['features'] is not None):
-            result_2['features'].extend(result_1['features'])
+    if result_1["features"] is not None:
+        if result_2["features"] is not None:
+            result_2["features"].extend(result_1["features"])
         else:
-            result_2['features'] =  result_1['features']
+            result_2["features"] = result_1["features"]
 
     return jsonify(result_2)
 

--- a/frontend/app/components/draw-form/draw-form.component.html
+++ b/frontend/app/components/draw-form/draw-form.component.html
@@ -2,7 +2,7 @@
   [options]="leafletDrawOptions"
   [zoomLevel]="1"
   (layerDrawed)="bindGeojsonForm($event)"
-  [geojson]="geoJsonService.currentLayer"
+  [geojson]="geomFromProtocol ? (geojson ? geojson.geometry : null) : geoJsonService.currentLayer"
   [bZoomOnPoint]="bZoomOnPoint"
   [zoomLevelOnPoint]="zoomLevelOnPoint"
   [bEnable]="bEdit"

--- a/frontend/app/components/draw-form/draw-form.component.html
+++ b/frontend/app/components/draw-form/draw-form.component.html
@@ -2,7 +2,7 @@
   [options]="leafletDrawOptions"
   [zoomLevel]="1"
   (layerDrawed)="bindGeojsonForm($event)"
-  [geojson]="geojson ? geojson.geometry : null"
+  [geojson]="geoJsonService.currentLayer"
   [bZoomOnPoint]="bZoomOnPoint"
   [zoomLevelOnPoint]="zoomLevelOnPoint"
   [bEnable]="bEdit"

--- a/frontend/app/components/draw-form/draw-form.component.ts
+++ b/frontend/app/components/draw-form/draw-form.component.ts
@@ -32,6 +32,8 @@ export class DrawFormComponent implements OnInit {
 
   @Input() bEdit;
 
+  @Input() geomFromProtocol: boolean = true;
+
   constructor(
     private _formService: FormService,
     public geoJsonService: GeoJSONService
@@ -86,7 +88,6 @@ export class DrawFormComponent implements OnInit {
       this.formValueChangeSubscription.unsubscribe();
     }
     if (this.parentFormControl && this.parentFormControl.value) {
-      console.log(this.parentFormControl)
       // init geometry from parentFormControl
       this.setGeojson(this.parentFormControl.value);
       // suivi formControl => composant

--- a/frontend/app/components/draw-form/draw-form.component.ts
+++ b/frontend/app/components/draw-form/draw-form.component.ts
@@ -32,8 +32,10 @@ export class DrawFormComponent implements OnInit {
 
   @Input() bEdit;
 
-  constructor(private _formService: FormService, public geoJsonService: GeoJSONService,) {
-  }
+  constructor(
+    private _formService: FormService,
+    public geoJsonService: GeoJSONService
+  ) {}
 
   ngOnInit() {
     // choix du type de geometrie
@@ -51,12 +53,14 @@ export class DrawFormComponent implements OnInit {
     this.displayed = true;
     switch (this.geometryType) {
       case 'Point': {
+        this.leafletDrawOptions.draw.polygon = false;
         this.leafletDrawOptions.draw.marker = {
           icon: new CustomMarkerIcon(),
         };
         break;
       }
       case 'Polygon': {
+        this.leafletDrawOptions.draw.marker = false;
         this.leafletDrawOptions.draw.polygon = {
           allowIntersection: false, // Restricts shapes to simple polygons
           drawError: {
@@ -118,9 +122,7 @@ export class DrawFormComponent implements OnInit {
 
   manageGeometryChange(geometry) {
     if (!isEqual(geometry, this.parentFormControl.value)) {
-      // this.geojsonService.removeFeatureGroup(this.geojson)
       this.parentFormControl.setValue(geometry);
-      // this.parentFormControl.markAsDirty();
     }
   }
 

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
@@ -83,7 +83,9 @@
             aria-hidden="true"
           ></i>
         </a>
-        <ng-container *ngIf="(child0.objectType == 'visit' ? true : row['nb_visits'] == 0) && this.canDeleteObj">
+        <ng-container
+          *ngIf="(child0.objectType == 'visit' ? true : row['nb_visits'] == 0) && this.canDeleteObj"
+        >
           <a
             [ngClass]="{ isDisableBtn: !row.cruved['D'] }"
             class="nav-link link cell-link"

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
@@ -83,7 +83,7 @@
             aria-hidden="true"
           ></i>
         </a>
-        <ng-container *ngIf="child0.objectType == 'visit' ? true : row['nb_visits'] == 0">
+        <ng-container *ngIf="(child0.objectType == 'visit' ? true : row['nb_visits'] == 0) && this.canDeleteObj">
           <a
             [ngClass]="{ isDisableBtn: !row.cruved['D'] }"
             class="nav-link link cell-link"

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
@@ -56,6 +56,7 @@ export class MonitoringDatatableComponent implements OnInit {
   bDeleteSpinner: boolean = false;
   toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
   canCreateChild: boolean = false;
+  canDeleteObj: boolean = false;
 
   constructor(
     private _monitoring: MonitoringObjectService,
@@ -72,6 +73,7 @@ export class MonitoringDatatableComponent implements OnInit {
     // TODO: Attention ici l'ajout avec l'icon ne se fait que sur un enfant (si plusieurs enfants au même niveau , le premier sera pris pour le moment)
     const childrenType = this.child0.config.children_types[0];
     this.canCreateChild = this.currentUser?.moduleCruved[childrenType]['C'];
+    this.canDeleteObj = !['site','sites_group'].includes(this.child0.objectType)
   }
 
   initDatatable() {

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
@@ -73,7 +73,7 @@ export class MonitoringDatatableComponent implements OnInit {
     // TODO: Attention ici l'ajout avec l'icon ne se fait que sur un enfant (si plusieurs enfants au même niveau , le premier sera pris pour le moment)
     const childrenType = this.child0.config.children_types[0];
     this.canCreateChild = this.currentUser?.moduleCruved[childrenType]['C'];
-    this.canDeleteObj = !['site','sites_group'].includes(this.child0.objectType)
+    this.canDeleteObj = !['site', 'sites_group'].includes(this.child0.objectType);
   }
 
   initDatatable() {

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.html
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.html
@@ -50,7 +50,7 @@
         <p
           class="alert alert-warning"
           style="display: inline-block; padding: 4px"
-          *ngIf="obj.config && obj.config['geometry_type'] && !objForm.static.value.geometry"
+          *ngIf="obj.config && obj.config['geometry_type'] && !objForm.static.value.geometry && obj.objectType != 'sites_group' "
         >
           <span> Veuillez saisir une géométrie sur la carte </span>
         </p>
@@ -61,7 +61,7 @@
           'form-scroll-info-geom':obj.config && obj.config['geometry_type'] && !objForm.static.value.geometry  ,
           'form-scroll': !(obj.config && obj.config['geometry_type'] && !objForm.static.value.geometry)}"
         >
-          <ng-container *ngIf="objForm.static">
+          <ng-container *ngIf="objForm.static && !isEmptyObject(objForm.static.controls)">
             <pnx-dynamic-form-generator
               class="obj-form"
               #dynamicForm

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.html
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.html
@@ -54,6 +54,16 @@
         >
           <span> Veuillez saisir une géométrie sur la carte </span>
         </p>
+        <p
+          class="alert alert-warning"
+          style="display: inline-block; padding: 4px"
+          *ngIf="obj.config && obj.config['geometry_type'] && !objForm.static.value.geometry && obj.objectType == 'sites_group' && obj.geometry == null "
+        >
+          <span>
+            La géométrie de groupe site est actuellement auto-générée sur la base des sites enfants
+            (si existants). Vous avez la possibilité de créer vous même une géométrie
+          </span>
+        </p>
         <!-- composant choix de site select + filtre -->
 
         <div

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.ts
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.ts
@@ -86,6 +86,7 @@ export class MonitoringFormComponentG implements OnInit {
   canDelete: boolean = false;
   canUpdate: boolean = false;
   canCreateOrUpdate: boolean = false;
+  geomCalculated: boolean = false;
 
   toolTipNotAllowed: string = TOOLTIPMESSAGEALERT;
   constructor(
@@ -96,7 +97,7 @@ export class MonitoringFormComponentG implements OnInit {
     private _dynformService: DynamicFormService,
     private _formService: FormService,
     private _router: Router,
-    private _geojsonService:GeoJSONService
+    private _geojsonService: GeoJSONService
   ) {}
 
   ngOnInit() {
@@ -167,7 +168,6 @@ export class MonitoringFormComponentG implements OnInit {
         })
       )
       .subscribe((data) => {
-        console.log(data.prop);
         this.initObj(data.prop);
         this.obj.config = this._configService.configModuleObject(
           this.obj.moduleCode,
@@ -232,7 +232,10 @@ export class MonitoringFormComponentG implements OnInit {
         // set geometry
         console.log(this.obj)
         if (this.obj.config && this.obj.config['geometry_type']) {
-          const validatorRequired = this.obj.objectType == 'sites_group' ? this._formBuilder.control('') : this._formBuilder.control('', Validators.required)
+          const validatorRequired =
+            this.obj.objectType == 'sites_group'
+              ? this._formBuilder.control('')
+              : this._formBuilder.control('', Validators.required);
           let frmCtrlGeom = {
             frmCtrl: validatorRequired,
             frmName: 'geometry',
@@ -243,7 +246,13 @@ export class MonitoringFormComponentG implements OnInit {
         this.isExtraForm && this.bEdit ? this.updateSpecificForm() : null;
         this.isExtraForm && !this.bEdit ? this.createSpecificForm() : null;
       });
-      this.bEdit ? this._geojsonService.setCurrentmapData(this.obj.geometry):null;
+    this.geomCalculated = this.obj.hasOwnProperty('is_geom_from_child')
+      ? this.obj.is_geom_from_child
+      : false;
+    this.bEdit
+      ? (this._geojsonService.removeAllFeatureGroup(),
+        this._geojsonService.setCurrentmapData(this.obj.geometry, this.geomCalculated))
+      : null;
   }
 
   /** pour réutiliser des paramètres déjà saisis */
@@ -540,6 +549,9 @@ export class MonitoringFormComponentG implements OnInit {
         .map((it) => it.path)
         .join('/');
       this._router.navigate([urlWithoutParams]);
+
+      this._geojsonService.removeAllFeatureGroup();
+      this._geojsonService.setMapBeforeEdit(this.obj.geometry);
       this.bEditChange.emit(false);
     } else {
       this.navigateToParent();
@@ -756,6 +768,6 @@ export class MonitoringFormComponentG implements OnInit {
   }
 
   isEmptyObject(obj) {
-    return (obj && (Object.keys(obj).length === 0));
+    return obj && Object.keys(obj).length === 0;
   }
 }

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.ts
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.ts
@@ -230,7 +230,6 @@ export class MonitoringFormComponentG implements OnInit {
 
         this.isExtraForm ? this.addExtraFormCtrl(data['frmCtrl']) : null;
         // set geometry
-        console.log(this.obj)
         if (this.obj.config && this.obj.config['geometry_type']) {
           const validatorRequired =
             this.obj.objectType == 'sites_group'
@@ -249,6 +248,7 @@ export class MonitoringFormComponentG implements OnInit {
     this.geomCalculated = this.obj.hasOwnProperty('is_geom_from_child')
       ? this.obj.is_geom_from_child
       : false;
+    this.geomCalculated ? (this.obj.geometry = null) : null;
     this.bEdit
       ? (this._geojsonService.removeAllFeatureGroup(),
         this._geojsonService.setCurrentmapData(this.obj.geometry, this.geomCalculated))
@@ -461,7 +461,6 @@ export class MonitoringFormComponentG implements OnInit {
       const urlWithoutParams = urlTree.root.children['primary'].segments
         .map((it) => it.path)
         .join('/');
-        console.log(urlWithoutParams)
       this._router.navigate([urlWithoutParams]);
     }
     this.bEditChange.emit(false);
@@ -499,7 +498,6 @@ export class MonitoringFormComponentG implements OnInit {
       : (this.bSaveSpinner = true);
     const { patch_update, ...sendValue } = this.dataForm;
     const objToUpdateOrCreate = this._formService.postData(sendValue, this.obj);
-    console.log(objToUpdateOrCreate)
     const action = this.obj.id
       ? this.apiService.patch(this.obj.id, objToUpdateOrCreate)
       : this.apiService.create(objToUpdateOrCreate);
@@ -551,7 +549,9 @@ export class MonitoringFormComponentG implements OnInit {
       this._router.navigate([urlWithoutParams]);
 
       this._geojsonService.removeAllFeatureGroup();
-      this._geojsonService.setMapBeforeEdit(this.obj.geometry);
+      this.obj.geometry == null
+        ? this._geojsonService.setMapDataWithFeatureGroup([this._geojsonService.sitesFeatureGroup])
+        : this._geojsonService.setMapBeforeEdit(this.obj.geometry);
       this.bEditChange.emit(false);
     } else {
       this.navigateToParent();

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -344,7 +344,6 @@ export class MonitoringFormComponent implements OnInit {
     this.obj.objectType == 'site'
       ? Object.assign(this.obj.config['specific'], this.schemaUpdate)
       : null;
-    console.log(objFormValueGroup)
     const action = this.obj.id
       ? this.obj.patch(objFormValueGroup, this.dataComplement)
       : this.obj.post(objFormValueGroup, this.dataComplement);
@@ -466,7 +465,6 @@ export class MonitoringFormComponent implements OnInit {
   }
 
   checkChangedTypeSite() {
-    console.log(this.typesSiteConfig);
     if ('types_site' in this.objFormDynamic.controls) {
       this.objFormDynamic.controls['types_site'].valueChanges
         .pipe(

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -344,6 +344,7 @@ export class MonitoringFormComponent implements OnInit {
     this.obj.objectType == 'site'
       ? Object.assign(this.obj.config['specific'], this.schemaUpdate)
       : null;
+    console.log(objFormValueGroup)
     const action = this.obj.id
       ? this.obj.patch(objFormValueGroup, this.dataComplement)
       : this.obj.post(objFormValueGroup, this.dataComplement);

--- a/frontend/app/components/monitoring-map-list/monitoring-map-list.component.html
+++ b/frontend/app/components/monitoring-map-list/monitoring-map-list.component.html
@@ -7,6 +7,7 @@
           [geometryType]="obj && obj.config && obj.config['geometry_type']"
           [bZoomOnPoint]="false"
           [bEdit]="bEdit"
+          [geomFromProtocol]="false"
         ></pnx-draw-form>
       </pnx-map>
     </div>

--- a/frontend/app/components/monitoring-map/monitoring-map.component.html
+++ b/frontend/app/components/monitoring-map/monitoring-map.component.html
@@ -8,6 +8,7 @@
       [geometryType]="obj && obj.config['geometry_type']"
       [bZoomOnPoint]="false"
       [bEdit]="bEdit"
+      [geomFromProtocol]="true"
     ></pnx-draw-form>
 
     <pnx-geojson

--- a/frontend/app/components/monitoring-object/monitoring-object.component.ts
+++ b/frontend/app/components/monitoring-object/monitoring-object.component.ts
@@ -157,7 +157,6 @@ export class MonitoringObjectComponent implements OnInit {
           }),
           type: 'FeatureCollection',
         };
-        console.log("sitesGroup",sitesGroup)
       }
       // affichage des sites du premier parent qui a des sites dans l'odre de parent Path
       let sites = null;
@@ -178,7 +177,6 @@ export class MonitoringObjectComponent implements OnInit {
         }),
         type: 'FeatureCollection',
       };
-      console.log("sites",sites)
       this.initObjectsStatus();
     });
   }

--- a/frontend/app/components/monitoring-object/monitoring-object.component.ts
+++ b/frontend/app/components/monitoring-object/monitoring-object.component.ts
@@ -157,6 +157,7 @@ export class MonitoringObjectComponent implements OnInit {
           }),
           type: 'FeatureCollection',
         };
+        console.log("sitesGroup",sitesGroup)
       }
       // affichage des sites du premier parent qui a des sites dans l'odre de parent Path
       let sites = null;
@@ -177,6 +178,7 @@ export class MonitoringObjectComponent implements OnInit {
         }),
         type: 'FeatureCollection',
       };
+      console.log("sites",sites)
       this.initObjectsStatus();
     });
   }

--- a/frontend/app/components/monitoring-sites/monitoring-sites.component.ts
+++ b/frontend/app/components/monitoring-sites/monitoring-sites.component.ts
@@ -252,7 +252,7 @@ export class MonitoringSitesComponent extends MonitoringGeomComponent implements
     if ($event == 'deleted') {
       return;
     }
-    this._geojsonService.removeAllFeatureGroup()
+    this._geojsonService.removeAllFeatureGroup();
     this.initSite();
   }
 

--- a/frontend/app/components/monitoring-sites/monitoring-sites.component.ts
+++ b/frontend/app/components/monitoring-sites/monitoring-sites.component.ts
@@ -126,16 +126,12 @@ export class MonitoringSitesComponent extends MonitoringGeomComponent implements
               );
             }),
             tap((data) => {
-              data.sitesGroup.is_geom_from_child ?
-                this._geojsonService.getSitesGroupsChildGeometries(this.onEachFeatureSite(), {
-                  id_sites_group: data.sitesGroup.id_sites_group,
-                }) 
-                :
-                this._geojsonService.setGeomSiteGroupFromExistingObject(
-                  data.sitesGroup.geometry
-                )
-              }
-            ),
+              data.sitesGroup.is_geom_from_child
+                ? this._geojsonService.getSitesGroupsChildGeometries(this.onEachFeatureSite(), {
+                    id_sites_group: data.sitesGroup.id_sites_group,
+                  })
+                : this._geojsonService.setGeomSiteGroupFromExistingObject(data.sitesGroup.geometry);
+            }),
             mergeMap((data) => {
               return forkJoin({
                 objObsSite: this._siteService.initConfig(),
@@ -180,7 +176,7 @@ export class MonitoringSitesComponent extends MonitoringGeomComponent implements
       });
   }
   ngOnDestroy() {
-    this._geojsonService.removeFeatureGroup(this._geojsonService.sitesFeatureGroup);
+    this._geojsonService.removeAllFeatureGroup();
     this.destroyed$.next(true);
     this.destroyed$.complete();
   }

--- a/frontend/app/services/form.service.ts
+++ b/frontend/app/services/form.service.ts
@@ -161,7 +161,9 @@ export class FormService {
     // TODO: A voir q'il faut remettre
     if (obj.config['geometry_type']) {
       postData['geometry'] = formValue['geometry'];
-      postData['type'] = 'Feature';
+      // if(postData['geometry'] != null){
+        postData['type'] = 'Feature';
+      // }
     }
     return postData;
   }

--- a/frontend/app/services/form.service.ts
+++ b/frontend/app/services/form.service.ts
@@ -162,7 +162,7 @@ export class FormService {
     if (obj.config['geometry_type']) {
       postData['geometry'] = formValue['geometry'];
       // if(postData['geometry'] != null){
-        postData['type'] = 'Feature';
+      postData['type'] = 'Feature';
       // }
     }
     return postData;

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -6,6 +6,7 @@ import { GeoJSON } from 'geojson';
 import { MapService } from '@geonature_common/map/map.service';
 
 import { SitesService, SitesGroupService } from './api-geom.service';
+import { FormService } from './form.service';
 
 // This service will be used for sites and sites groups
 
@@ -24,12 +25,19 @@ export class GeoJSONService {
   geojsonSites: GeoJSON.FeatureCollection;
   sitesGroupFeatureGroup: L.FeatureGroup;
   sitesFeatureGroup: L.FeatureGroup;
+  currentLayer:any = null ;
 
+  // private currentLayer = new ReplaySubject<any>(1);
+  // currentLayerForm = this.currentLayer.asObservable();
+  
   constructor(
     private _sites_group_service: SitesGroupService,
     private _sites_service: SitesService,
-    private _mapService: MapService
-  ) {}
+    private _mapService: MapService,
+    private _formService: FormService
+  ) {
+    // this.setObservables()
+  }
 
   getSitesGroupsGeometries(onEachFeature: Function, params = {}) {
     this._sites_group_service
@@ -47,6 +55,10 @@ export class GeoJSONService {
     });
   }
 
+  setGeomSiteGroupFromExistingObject(geom){
+    this.sitesFeatureGroup = this.setMapData(geom, () => {});
+  }
+
   setMapData(
     geojson: GeoJSON.Geometry | GeoJSON.FeatureCollection,
     onEachFeature: Function,
@@ -61,11 +73,37 @@ export class GeoJSONService {
     return featureGroup;
   }
 
+  setMapDataWithFeatureGroup(
+    featureGroup: L.FeatureGroup[],
+  ) {
+    for (const layer of featureGroup){
+      this._mapService.map.addLayer(layer);
+    }
+  }
+
+  setCurrentmapData(geom){
+    this.currentLayer = geom
+  }
+
+  setMapBeforeEdit(geom){
+    this.currentLayer = null;
+    this.setMapData(geom, () => {});
+  }
+
   removeFeatureGroup(feature: L.FeatureGroup) {
     if (feature) {
       this._mapService.map.removeLayer(feature);
     }
   }
+
+  removeLayerFeatureGroups() {
+    return this._mapService.removeLayerFeatureGroups
+  }
+
+  fileLayerFeatureGroup(){
+    return   this._mapService.fileLayerFeatureGroup
+  }
+
 
   onEachFeature() {}
 
@@ -113,4 +151,19 @@ export class GeoJSONService {
     });
     return layers;
   }
+  
+  removeAllFeatureGroup(){
+    // this._mapService.removeAllLayers(this._mapService.map,this._mapService.fileLayerFeatureGroup)
+    let listFeatureGroup: L.FeatureGroup[] = []
+    this._mapService.map.eachLayer( function(layer) {
+    if (layer instanceof L.FeatureGroup){
+      listFeatureGroup.push(layer)
+    }
+    } );
+    // this.currentLayer = listFeatureGroup
+    for (const featureGroup of listFeatureGroup){
+      this.removeFeatureGroup(featureGroup)
+    }
+  }
+
 }

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -25,7 +25,7 @@ export class GeoJSONService {
   geojsonSites: GeoJSON.FeatureCollection;
   sitesGroupFeatureGroup: L.FeatureGroup;
   sitesFeatureGroup: L.FeatureGroup;
-  currentLayer:any = null ;
+  currentLayer: any = null;
 
   // private currentLayer = new ReplaySubject<any>(1);
   // currentLayerForm = this.currentLayer.asObservable();
@@ -35,9 +35,7 @@ export class GeoJSONService {
     private _sites_service: SitesService,
     private _mapService: MapService,
     private _formService: FormService
-  ) {
-    // this.setObservables()
-  }
+  ) {}
 
   getSitesGroupsGeometries(onEachFeature: Function, params = {}) {
     this._sites_group_service
@@ -55,8 +53,8 @@ export class GeoJSONService {
     });
   }
 
-  setGeomSiteGroupFromExistingObject(geom){
-    this.sitesFeatureGroup = this.setMapData(geom, () => {});
+  setGeomSiteGroupFromExistingObject(geom) {
+    this.sitesGroupFeatureGroup = this.setMapData(geom, () => {});
   }
 
   setMapData(
@@ -73,19 +71,19 @@ export class GeoJSONService {
     return featureGroup;
   }
 
-  setMapDataWithFeatureGroup(
-    featureGroup: L.FeatureGroup[],
-  ) {
-    for (const layer of featureGroup){
+  setMapDataWithFeatureGroup(featureGroup: L.FeatureGroup[]) {
+    for (const layer of featureGroup) {
       this._mapService.map.addLayer(layer);
     }
   }
 
-  setCurrentmapData(geom){
-    this.currentLayer = geom
+  setCurrentmapData(geom, isGeomCalculated) {
+    isGeomCalculated
+      ? (this.currentLayer = null)
+      : ((this.currentLayer = geom), this._mapService.loadGeometryReleve(geom, false));
   }
 
-  setMapBeforeEdit(geom){
+  setMapBeforeEdit(geom) {
     this.currentLayer = null;
     this.setMapData(geom, () => {});
   }
@@ -151,19 +149,16 @@ export class GeoJSONService {
     });
     return layers;
   }
-  
-  removeAllFeatureGroup(){
-    // this._mapService.removeAllLayers(this._mapService.map,this._mapService.fileLayerFeatureGroup)
-    let listFeatureGroup: L.FeatureGroup[] = []
-    this._mapService.map.eachLayer( function(layer) {
-    if (layer instanceof L.FeatureGroup){
-      listFeatureGroup.push(layer)
-    }
-    } );
-    // this.currentLayer = listFeatureGroup
-    for (const featureGroup of listFeatureGroup){
-      this.removeFeatureGroup(featureGroup)
+
+  removeAllFeatureGroup() {
+    let listFeatureGroup: L.FeatureGroup[] = [];
+    this._mapService.map.eachLayer(function (layer) {
+      if (layer instanceof L.FeatureGroup) {
+        listFeatureGroup.push(layer);
+      }
+    });
+    for (const featureGroup of listFeatureGroup) {
+      this.removeFeatureGroup(featureGroup);
     }
   }
-
 }

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -27,9 +27,6 @@ export class GeoJSONService {
   sitesFeatureGroup: L.FeatureGroup;
   currentLayer: any = null;
 
-  // private currentLayer = new ReplaySubject<any>(1);
-  // currentLayerForm = this.currentLayer.asObservable();
-  
   constructor(
     private _sites_group_service: SitesGroupService,
     private _sites_service: SitesService,
@@ -73,14 +70,14 @@ export class GeoJSONService {
 
   setMapDataWithFeatureGroup(featureGroup: L.FeatureGroup[]) {
     for (const layer of featureGroup) {
-      this._mapService.map.addLayer(layer);
+      if (layer != undefined) {
+        this._mapService.map.addLayer(layer);
+      }
     }
   }
 
   setCurrentmapData(geom, isGeomCalculated) {
-    isGeomCalculated
-      ? (this.currentLayer = null)
-      : ((this.currentLayer = geom), this._mapService.loadGeometryReleve(geom, false));
+    isGeomCalculated ? (this.currentLayer = null) : (this.currentLayer = geom);
   }
 
   setMapBeforeEdit(geom) {
@@ -93,15 +90,6 @@ export class GeoJSONService {
       this._mapService.map.removeLayer(feature);
     }
   }
-
-  removeLayerFeatureGroups() {
-    return this._mapService.removeLayerFeatureGroups
-  }
-
-  fileLayerFeatureGroup(){
-    return   this._mapService.fileLayerFeatureGroup
-  }
-
 
   onEachFeature() {}
 


### PR DESCRIPTION
Entrée par site / groupe de site : 

- Ajout d'une revision alembic pour ajouter la géométrie à la table `t_sites_groups` (basé sur la table `t_base_site` --> trigger, index et colonnes geom et geom_local)
- Création de groupe de site possible en ajoutant dans le fichier de config site_group.json le champ par exemple`geometry_type : Polygon`
- Géométrie auto-générée sur la base des sites enfants 
- Si Géométrie créée pour un groupe de site alors c'est cette dernière qui sera chargé pour les fois suivantes (pas de possibilité de revenir à une géométrie auto-générée une fois qu'elle a été créée par l'utilisateur)
- Message prévenant l'utilisateur si la géométrie est pour le moment auto-générée et qu'il a la possibilité de créer sa propre géométrie
- Edition de géométrie de groupe de site

