### PR TITLE
fix: error on delete child from table

### DIFF
--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
@@ -263,12 +263,15 @@ export class MonitoringDatatableComponent implements OnInit {
   }
 
   onDelete(row) {
-    this._commonService.regularToaster('info', this.msgToaster('Suppression'));
-    this._objectService.changeDisplayingDeleteModal(this.bDeleteModal);
-    this._objectService.changeSelectRow({ rowSelected: row, objectType: this.child0.objectType });
-    this._objectService.currentDeleteModal.subscribe(
-      (deletedModal) => (this.bDeleteModal = deletedModal)
-    );
+    this.child0.id = row.id
+    this.child0.delete().subscribe((objData) => {
+      this.bDeleteSpinner = this.bDeleteModal = false;
+      this.child0.deleted = true;
+      this._commonService.regularToaster('info', this.msgToaster('Suppression'));
+      setTimeout(() => {
+        window.location.reload()
+      }, 100);
+    });
   }
 
   alertMessage(row) {


### PR DESCRIPTION
Use window.location.reload in order to update table (tried to reload this.obj with new data but cache is kept --> cache is deleted only if main obj is deleted not if child is deleted when the url target specific obj

Reviewed-by: andriacap